### PR TITLE
Remove check `weap_area_refn != ""` from func weap_keep

### DIFF
--- a/gi_loadouts/face/wind/calc.py
+++ b/gi_loadouts/face/wind/calc.py
@@ -103,7 +103,6 @@ class Assess:
         """
         if (self.weap_area_type.currentText().strip() != "" and
             self.weap_area_name.currentText().strip() != "" and
-            self.weap_area_refn.currentText().strip() != "" and
             self.weap_area_levl.currentText().strip() != ""):
             # MAIN
             kind = self.weap_area_type.currentText().strip()


### PR DESCRIPTION
Remove check weap_area_refn != "" from func weap_keep so that final calculation can also work for weapons without any refinement

![Screenshot from 2024-08-29 17-53-57](https://github.com/user-attachments/assets/d5189f13-09f7-43fa-873c-157a186c6f57)
![Screenshot from 2024-08-29 17-54-00](https://github.com/user-attachments/assets/a6dda037-c231-440e-b746-12ed8f8b5f2b)
