### PR TITLE
Set weapon type as `Claymore` for `Dori`

### DIFF
--- a/gi_loadouts/data/char/dori.py
+++ b/gi_loadouts/data/char/dori.py
@@ -12,7 +12,7 @@ class Dori(Char):
     rare: Rare = Rare.Star_4
     base: BaseStat = BaseStat(attack=18.6984, defense=60.6585, health_points=1039.4418)
     ascn: BaseStat = BaseStat(attack=66.90411, defense=217.035, health_points=3719.104)
-    weapon: WeaponType = WeaponType.catalyst
+    weapon: WeaponType = WeaponType.claymore
     vision: Vision = Vision.electro
     cons_name: str = "Magicae Lucerna"
     afln: str = "The Palace of Alcazarzaray"


### PR DESCRIPTION
Set weapon type as `Claymore` for `Dori`

![Screenshot from 2024-08-29 18-11-01](https://github.com/user-attachments/assets/4790b7f8-92ec-40dc-bb67-53ca7ab48b3e)
![Screenshot from 2024-08-29 18-16-46](https://github.com/user-attachments/assets/1d0aabc7-6bd9-4b95-9dd5-9a4542b12cc3)

Fixes Issue https://github.com/gridhead/gi-loadouts/issues/64