### PR TITLE
Rename the SecoStatType members to match the naming convention

### DIFF
--- a/gi_loadouts/type/arti/base/__init__.py
+++ b/gi_loadouts/type/arti/base/__init__.py
@@ -79,8 +79,8 @@ class SecoStatType(Enum):
     health_points_perc = STAT.health_points_perc
     elemental_mastery = STAT.elemental_mastery
     energy_recharge_perc = STAT.energy_recharge_perc
-    critical_rate = STAT.critical_rate_perc
-    critical_damage = STAT.critical_damage_perc
+    critical_rate_perc = STAT.critical_rate_perc
+    critical_damage_perc = STAT.critical_damage_perc
     none = STAT.none
 
 


### PR DESCRIPTION
Rename the SecoStatType members to match the naming convention

- critical_rate >> critical_rate_perc
- critical_damage >> critical_damage_perc

```python
class SecoStatType(Enum):
    """
    Set of possible secondary stat types in an artifact
    """
    attack = STAT.attack
    attack_perc = STAT.attack_perc
    defense = STAT.defense
    defense_perc = STAT.defense_perc
    health_points = STAT.health_points
    health_points_perc = STAT.health_points_perc
    elemental_mastery = STAT.elemental_mastery
    energy_recharge_perc = STAT.energy_recharge_perc
    critical_rate_perc = STAT.critical_rate_perc
    critical_damage_perc = STAT.critical_damage_perc
    none = STAT.none
```
Fixes #99 