### PR TITLE
Apply logical correction in `SAVE` and `LOAD` for weapons with no refinement

### DIFF
--- a/gi_loadouts/face/wind/fclt.py
+++ b/gi_loadouts/face/wind/fclt.py
@@ -139,7 +139,9 @@ class Facility(Dialog):
         :return:
         """
         try:
-            if self.weap_area_type.currentText() != "" and self.weap_area_name.currentText() != "" and self.weap_area_refn.currentText() != "" and self.weap_area_levl.currentText() != "":
+            if (self.weap_area_type.currentText() != "" and
+                self.weap_area_name.currentText() != "" and
+                self.weap_area_levl.currentText() != ""):
                 objc = WeapFile(
                     name=self.weap_area_name.currentText(),
                     type=getattr(WeaponType, self.weap_area_type.currentText().lower()),
@@ -263,7 +265,9 @@ class Facility(Dialog):
         :return:
         """
         try:
-            if self.weap_area_type.currentText() != "" and self.weap_area_name.currentText() != "" and self.weap_area_refn.currentText() != "" and self.weap_area_levl.currentText() != "":
+            if (self.weap_area_type.currentText() != "" and
+                self.weap_area_name.currentText() != "" and
+                self.weap_area_levl.currentText() != ""):
                 data = file.load(
                     self,
                     "Select location to load weapon data"
@@ -291,7 +295,7 @@ class Facility(Dialog):
                 self.weap_area_levl.setCurrentText(weap.levl.value.name)
 
                 refnlist = [self.weap_area_refn.itemText(indx) for indx in range(self.weap_area_refn.count())]
-                if weap.refn not in refnlist:
+                if weap.refn and weap.refn not in refnlist:
                     raise ValueError("Weapon refinement cannot be parsed.")
                 self.weap_area_refn.setCurrentText(weap.refn)
 


### PR DESCRIPTION
Apply logical correction in `SAVE` and `LOAD` for weapons with no refinement

- Remove check of `weap_area_refn != ""` from func `weap_save` and `weap_load`
- Add check for the availability of refinement in the weapon file object

![Screenshot from 2024-09-08 18-21-41](https://github.com/user-attachments/assets/a027e0df-93b2-416a-8501-9c35542b80a8)

```
levl: Level 65/70 (Rank 4)
name: Dull Blade
refn: ''
type: sword
```

Fix #116 