### PR TITLE
Modify logic of `MAINSTAT` scanning and correct the `REGEX` for ER

### DIFF
--- a/gi_loadouts/face/scan/__init__.py
+++ b/gi_loadouts/face/scan/__init__.py
@@ -35,7 +35,7 @@ For eg. `ATK+6.9%` can be seen as `ATK+6` (absolute unit) and `ATK+6.9%` (relati
 
 substats = {
     r".*Elemental\s*Mastery\+[0-9]+.*": STAT.elemental_mastery,
-    r".*Energy\s+Recharge\+[0-9]*\.[0-9]+%.*": STAT.energy_recharge_perc,
+    r".*Energy\s*Recharge\+[0-9]*\.[0-9]+%.*": STAT.energy_recharge_perc,
     r".*CRIT\s*Rate\+[0-9]*\.[0-9]+%.*": STAT.critical_rate_perc,
     r".*CRIT\s*DMG\+[0-9]*\.[0-9]+%.*": STAT.critical_damage_perc,
     r".*HP\+[0-9]*\.[0-9]+%.*": STAT.health_points_perc,
@@ -55,7 +55,7 @@ mainstat = {
     },
     "Sands of Eon": {
         r".*Elemental\s*Mastery.*": STAT.elemental_mastery,
-        r".*Energy\s+Recharge.*": STAT.energy_recharge_perc,
+        r".*Energy\s*Recharge.*": STAT.energy_recharge_perc,
         r".*HP.*": STAT.health_points_perc,
         r".*DEF.*": STAT.defense_perc,
         r".*ATK.*": STAT.attack_perc,

--- a/gi_loadouts/face/scan/util.py
+++ b/gi_loadouts/face/scan/util.py
@@ -77,6 +77,11 @@ def scan_artifact(snap: ImageFile) -> tuple:
     else:
         calcdict = {item: data for dinx in mainstat.values() for item, data in dinx.items()}
 
+    if "+" in text:
+        plus_indx = text.index("+")
+    else:
+        plus_indx = len(text)
+
     for ptrn, name in calcdict.items():
         """
         As the mainstats are always shown before the level indicator of the artifact, we can safely
@@ -84,7 +89,7 @@ def scan_artifact(snap: ImageFile) -> tuple:
         the `+` sign is the mainstat of the artifact. There, of course, are pitfalls for whenever
         the `+` sign cannot be reliably read but there is only so much that we can do here.
         """
-        mtch = search(ptrn, text[0:text.index("+")])
+        mtch = search(ptrn, text[0:plus_indx])
         if mtch:
             """
             It is possible for artifacts having absolute HP, DEF and ATK units as their mainstat to
@@ -92,7 +97,7 @@ def scan_artifact(snap: ImageFile) -> tuple:
             presence of HP, DEF, ATK, HP%, DEF% and ATK% units in the substats is accounted for
             when one of these is also in the mainstat, a localized replacement must be performed.
             """
-            text = text[0:text.index("+")].replace(mtch.group(), "") + text[text.index("+"):]
+            text = text[0:plus_indx].replace(mtch.group(), "") + text[plus_indx:]
             main = ATTR(stat_name=name, stat_data=0.0)
             break
 


### PR DESCRIPTION
Modify logic of `MAINSTAT` scanning and correct the `REGEX` for ER

- Add a check for existence of `+` in text generated by OCR while scanning for `MAINSTAT`
- Correct the `REGEX` for `Energy Recharge` in `substats` and `mainstat` to check spaces between `Energy` and `Recharge`

![Screenshot from 2024-09-09 09-57-55](https://github.com/user-attachments/assets/cae41726-3830-4b31-bcd0-c459d9eaecd6)
![Screenshot from 2024-09-09 09-58-11](https://github.com/user-attachments/assets/e1175498-c5fd-4bbc-b149-965f93517dcb)
![Screenshot from 2024-09-09 10-00-46](https://github.com/user-attachments/assets/504acf54-f24c-45c4-b022-c2d8cc13165e)

Fix #120 