### PR TITLE
Add exception handling in the destructor `scan/rule.py`

### DIFF
--- a/gi_loadouts/face/scan/rule.py
+++ b/gi_loadouts/face/scan/rule.py
@@ -53,8 +53,11 @@ class Rule(QDialog, Ui_scan, Dialog):
         This is not likely to cause major problems but still, this is not the right approach and
         should be rectified at the earliest, no matter how small of a use-case this might be.
         """
-        if isinstance(self.thread, QThread):
-            self.thread.terminate()
+        try:
+            if isinstance(self.thread, QThread):
+                self.thread.terminate()
+        except RuntimeError:
+            return
 
     def populate_dropdown(self) -> None:
         """


### PR DESCRIPTION
Add exception handling in the destructor `scan/rule.py`

If `QThread` is stopped and `__del__()` attempts to terminate it afterward, a Runtime Error is thrown, which has no effect on the UI's functioning but raises an error in the console. Thus, if such an exception occurs, there is no need to display an exception in the terminal.

Fixes: #190