### PR TITLE
Fix the GitHub Actions CI after Fedora Linux 41 update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   ci-test:
     runs-on: ubuntu-latest
-    container: fedora:latest
+    container: fedora:40
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fix the GitHub Actions CI after Fedora Linux 41 update