### PR TITLE
Add check for `filepath` to return either `False` or `True`

### DIFF
--- a/gi_loadouts/face/scan/file.py
+++ b/gi_loadouts/face/scan/file.py
@@ -32,6 +32,8 @@ class FileHandling:
         """
         explorer = QFileDialog()
         filepath = explorer.getOpenFileName(prnt, head, "", "All Files (*)")[0]
+        if filepath.strip() == "":
+            return False, None, None
         return True, *self.load_mask_from_file(filepath)
 
     def load_tessexec_with_picker(self, prnt, head: str) -> Tuple[bool, str]:

--- a/test/face/scan/test_scan.py
+++ b/test/face/scan/test_scan.py
@@ -289,7 +289,7 @@ def test_scan_arti_load_nope(scantest: ScanDialog, qtbot: QtBot, mocker: MockerF
     """
     Perform the action of loading the artifact information
     """
-    mocker.patch.object(file.FileHandling, "load_screenshot_with_picker", return_value=(False, None, None))
+    mocker.patch.object(file.QFileDialog, "getOpenFileName", return_value=("", ""))
     qtbot.mouseClick(scantest.arti_cnvs_load, Qt.LeftButton)
 
     """


### PR DESCRIPTION
Add check for `snap` NOT `None` to move forward

[Screencast from 2024-11-02 14-54-12.webm](https://github.com/user-attachments/assets/77ee09ab-a3f9-4d1e-a4ad-2f617b4e1694)

Fixes: #203 