### PR TITLE
Fix issue #163: Fix the tests for the Sword weapon called Sword of De…

### DIFF
--- a/gi_loadouts/type/weap/__init__.py
+++ b/gi_loadouts/type/weap/__init__.py
@@ -101,6 +101,18 @@ class Weapon(BaseModel):
 
         if self.rare in [Rare.Star_1, Rare.Star_2]:
             mult = Mult[Rare.Star_3][self.levl.value.qant].data[self.tier]
+        elif self.file == "sods" and self.name == "Sword of Descension":
+            """
+            `Sword of Descension` is a special weapon. Although it is a 4-Star rarity weapon which
+            uses the 4-Star ascension value, it actually uses 3-Star Tier 2 base value and
+            multipliers.
+
+            Although this is an anti-pattern and we do not generally support such kinds of
+            development, we have implemented this specific calculation to ensure the displayed
+            values are accurate for users.
+            """
+            base = Tier.Tier_2.value["rare"][Rare.Star_3.value.qant]
+            mult = Mult[Rare.Star_3][self.levl.value.qant].data[self.tier]
         else:
             mult = Mult[self.rare][self.levl.value.qant].data[self.tier]
 

--- a/test/data/weap/test_sword.py
+++ b/test/data/weap/test_sword.py
@@ -55,8 +55,8 @@ from test import verify_accuracy
         pytest.param("Absolution", 5, 3, "Level 80/90 (Rank 6)", 621, WeaponStatType.critical_damage_perc, 40.2, id="data.weap.swords: Absolution"),
         pytest.param("Aquila Favonia", 5, 3, "Level 80/90 (Rank 6)", 621, WeaponStatType.damage_bonus_physical_perc, 37.7, id="data.weap.swords: Aquila Favonia"),
         pytest.param("Mistsplitter Reforged", 5, 3, "Level 80/90 (Rank 6)", 621, WeaponStatType.critical_damage_perc, 40.2, id="data.weap.swords: Mistsplitter Reforged"),
-        pytest.param("The Alley Flash", 4, 4, "Level 80/90 (Rank 6)", 571, WeaponStatType.elemental_mastery, 50, id="data.weap.swords: The Alley Flash")
-        #TODO pytest.param("Sword of Descension", 0, 0, "Level 80/90 (Rank 6)", 414, WeaponStatType.attack_perc, 32.1, id="data.weap.swords: Sword of Descension"),
+        pytest.param("The Alley Flash", 4, 4, "Level 80/90 (Rank 6)", 571, WeaponStatType.elemental_mastery, 50, id="data.weap.swords: The Alley Flash"),
+        pytest.param("Sword of Descension", 4, 2, "Level 80/90 (Rank 6)", 414, WeaponStatType.attack_perc, 32.1, id="data.weap.swords: Sword of Descension")
     ]
 )
 def test_sword(name: str, rare: int, tier: int, levl: str, batk: int, seco: WeaponStatType, valu: float) -> None:

--- a/test/face/wind/weap/kind/test_sword.py
+++ b/test/face/wind/weap/kind/test_sword.py
@@ -55,8 +55,8 @@ from test import verify_accuracy
         pytest.param("Absolution", 5, "Level 80/90 (Rank 6)", 621, WeaponStatType.critical_damage_perc, 40.2, 5, id="face.wind.rule: Configuring weapon - Sword - Absolution"),
         pytest.param("Aquila Favonia", 5, "Level 80/90 (Rank 6)", 621, WeaponStatType.damage_bonus_physical_perc, 37.7, 5, id="face.wind.rule: Configuring weapon - Sword - Aquila Favonia"),
         pytest.param("Mistsplitter Reforged", 5, "Level 80/90 (Rank 6)", 621, WeaponStatType.critical_damage_perc, 40.2, 5, id="face.wind.rule: Configuring weapon - Sword - Mistsplitter Reforged"),
-        pytest.param("The Alley Flash", 4, "Level 80/90 (Rank 6)", 571, WeaponStatType.elemental_mastery, 50, 5, id="face.wind.rule: Configuring weapon - Sword - The Alley Flash")
-        #TODO pytest.param("Sword of Descension", 0, "Level 80/90 (Rank 6)", 414, WeaponStatType.attack_perc, 32.1, 5, id="face.wind.rule: Configuring weapon - Sword - Sword of Descension"),
+        pytest.param("The Alley Flash", 4, "Level 80/90 (Rank 6)", 571, WeaponStatType.elemental_mastery, 50, 5, id="face.wind.rule: Configuring weapon - Sword - The Alley Flash"),
+        pytest.param("Sword of Descension", 4, "Level 80/90 (Rank 6)", 414, WeaponStatType.attack_perc, 32.1, 1, id="face.wind.rule: Configuring weapon - Sword - Sword of Descension")
     ]
 )
 def test_sword(runner: MainWindow, name: str, rare: int, levl: str, batk: int, seco: WeaponStatType, valu: float, refn: int | None) -> None:


### PR DESCRIPTION
I'm not sure I've fully grasped the issue #163, but I gave it a try nevertheless so don't hesitate to correct me if I'm wrong.

So to my understanding the sword called "Sword of Descension" despite being 4* rarity, uses different values for its Main Stat calculation as stated in the Genshin wiki : 
![image](https://github.com/user-attachments/assets/516c8658-ce7b-42ec-9d8e-20de77917850)
Hence, its Level up scaling is comparable to a sword of 3* rarity, which is why the test would not pass as we ended up with a Main Stat value much higher than expected.

To reflect this, I've made simple changes in the weapons main stat calculation by adding a condition to handle this sword specifically with the right values.