### PR TITLE
Add the missing `refi_stat` values for new weapon `Starcaller's Watch`

### DIFF
--- a/gi_loadouts/data/weap/catalysts/scwh.py
+++ b/gi_loadouts/data/weap/catalysts/scwh.py
@@ -18,4 +18,11 @@ class StarcallersWatch(Catalyst):
         "Increases Elemental Mastery by 175. Gain the \"Mirror of Night\" effect within 15s after the equipping character creates a shield: The current active party member deals 49% increased DMG to nearby opponents. You can gain the \"Mirror of Night\" effect once every 14s.",
         "Increases Elemental Mastery by 200. Gain the \"Mirror of Night\" effect within 15s after the equipping character creates a shield: The current active party member deals 56% increased DMG to nearby opponents. You can gain the \"Mirror of Night\" effect once every 14s.",
     ]
+    refi_stat: List[WeaponStat] = [
+        [WeaponStat(stat_name=WeaponStatType.elemental_mastery, stat_data=100.0)],
+        [WeaponStat(stat_name=WeaponStatType.elemental_mastery, stat_data=125.0)],
+        [WeaponStat(stat_name=WeaponStatType.elemental_mastery, stat_data=150.0)],
+        [WeaponStat(stat_name=WeaponStatType.elemental_mastery, stat_data=175.0)],
+        [WeaponStat(stat_name=WeaponStatType.elemental_mastery, stat_data=200.0)],
+    ]
     file: str = "scwh"


### PR DESCRIPTION
Addition `Elemental Mastery` received from the new weapon `Starcaller's Watch` was not included, thus adding the missing `refi_stat` values.

Refinement 5
![Screenshot From 2025-01-04 00-22-07](https://github.com/user-attachments/assets/4149dedc-caf5-4433-bfc7-821f8b75ec1d)
![Screenshot From 2025-01-04 00-21-56](https://github.com/user-attachments/assets/7d689640-a75c-46a2-b792-a3c640a815bf)

Refinement 1
![Screenshot From 2025-01-04 00-21-45](https://github.com/user-attachments/assets/4a7cfbb9-61a5-4437-9b4a-f715416e59b6)
![Screenshot From 2025-01-04 00-21-38](https://github.com/user-attachments/assets/ccb0a383-408c-4a4c-b27d-4147e7d2fd2c)
