### PR TITLE
Fix #253: correct multipliers for travelers

### DIFF
--- a/gi_loadouts/data/char/aether.py
+++ b/gi_loadouts/data/char/aether.py
@@ -1,11 +1,11 @@
-from gi_loadouts.type.char import BaseStat, Char
+from gi_loadouts.type.char import BaseStat, MainChar
 from gi_loadouts.type.rare import Rare
 from gi_loadouts.type.stat import STAT
 from gi_loadouts.type.vson import Vision
 from gi_loadouts.type.weap import WeaponType
 
 
-class Aether(Char):
+class Aether(MainChar):
     __statdata__: dict = {0: 0.0, 1: 0.0, 2: 6.0, 3: 12.0, 4: 12.0, 5: 18.0, 6: 24.0}
     __statname__: STAT = STAT.attack_perc
     name: str = "Aether"

--- a/gi_loadouts/data/char/lumine.py
+++ b/gi_loadouts/data/char/lumine.py
@@ -1,11 +1,11 @@
-from gi_loadouts.type.char import BaseStat, Char
+from gi_loadouts.type.char import BaseStat, MainChar
 from gi_loadouts.type.rare import Rare
 from gi_loadouts.type.stat import STAT
 from gi_loadouts.type.vson import Vision
 from gi_loadouts.type.weap import WeaponType
 
 
-class Lumine(Char):
+class Lumine(MainChar):
     __statdata__: dict = {0: 0.0, 1: 0.0, 2: 6.0, 3: 12.0, 4: 12.0, 5: 18.0, 6: 24.0}
     __statname__: STAT = STAT.attack_perc
     name: str = "Lumine"

--- a/gi_loadouts/type/char/__init__.py
+++ b/gi_loadouts/type/char/__init__.py
@@ -136,6 +136,19 @@ class Char(BaseModel):
     afln: str = ""
     head: str = ""
 
+    def _calc_stat(self, base_stat: float, ascension_stat: float, stat_type: STAT) -> ATTR:
+        """
+        Generalized stat calculation method for attack, defense, and health points.
+
+        :param base_stat: BaseStat value for the character (attack, defense, or health).
+        :param ascension_stat: Ascension value for the given stat.
+        :param stat_type: Type of the stat (STAT.attack, STAT.defense, or STAT.health_points).
+        :return: ATTR instance with calculated stat value.
+        """
+        stat_data = base_stat * Mult[self.levl.value.qant][self.rare] + Secs[self.levl.value.rank] * ascension_stat
+
+        return ATTR(stat_name=stat_type, stat_data=stat_data)
+
     @property
     def attack(self) -> ATTR:
         """
@@ -143,10 +156,7 @@ class Char(BaseModel):
 
         :return: Attack potential associated with the character
         """
-        return ATTR(
-            stat_name=STAT.attack,
-            stat_data=self.base.attack * Mult[self.levl.value.qant][self.rare] + Secs[self.levl.value.rank] * self.ascn.attack
-        )
+        return self._calc_stat(self.base.attack, self.ascn.attack, STAT.attack)
 
     @property
     def defense(self) -> ATTR:
@@ -155,10 +165,7 @@ class Char(BaseModel):
 
         :return: Defense potential associated with the character
         """
-        return ATTR(
-            stat_name=STAT.defense,
-            stat_data=self.base.defense * Mult[self.levl.value.qant][self.rare] + Secs[self.levl.value.rank] * self.ascn.defense
-        )
+        return self._calc_stat(self.base.defense, self.ascn.defense, STAT.defense)
 
     @property
     def health_points(self) -> ATTR:
@@ -167,10 +174,7 @@ class Char(BaseModel):
 
         :return: Health points potential associated with the character
         """
-        return ATTR(
-            stat_name=STAT.health_points,
-            stat_data=self.base.health_points * Mult[self.levl.value.qant][self.rare] + Secs[self.levl.value.rank] * self.ascn.health_points
-        )
+        return self._calc_stat(self.base.health_points, self.ascn.health_points, STAT.health_points)
 
     @property
     def seco(self) -> SecoStat:
@@ -183,6 +187,29 @@ class Char(BaseModel):
             stat_name=self.__statname__,
             stat_data=self.__statdata__[self.levl.value.rank.value]
         )
+
+
+class MainChar(Char):
+    """
+    Main character primitive
+    """
+
+    def _calc_stat(self, base_stat: float, ascension_stat: float, stat_type: STAT) -> ATTR:
+        """
+        `Aether` and `Lumine` are special characters. Although they are 5-Star quality
+        characters which use the 5-Star Level Multiplier values, they actually use 4-Star
+        Level Multipliers. Although this is an anti-pattern and we do not generally
+        support such kinds of development, we have implemented this specific calculation
+        to ensure the displayed values are accurate for users.
+
+        :param base_stat: BaseStat value for the character (attack, defense, or health).
+        :param ascension_stat: Ascension value for the given stat.
+        :param stat_type: Type of the stat (STAT.attack, STAT.defense, or STAT.health_points).
+        :return: ATTR instance with calculated stat value.
+        """
+        stat_data = base_stat * Mult[self.levl.value.qant][Rare.Star_4] + Secs[self.levl.value.rank] * ascension_stat
+
+        return ATTR(stat_name=stat_type, stat_data=stat_data)
 
 
 class BaseStat(BaseModel):


### PR DESCRIPTION
### **This change ensures that the base stats match the expected values as documented on the Wiki.**

As stated in https://github.com/gridhead/gi-loadouts/pull/253#issuecomment-2618961889 the Travelers seems to be using the 4 star Multiplier values despite being categorized as 5 star characters.
![image](https://github.com/user-attachments/assets/df82432a-693b-4885-bea2-625c1bb48b1b)

**- lvl 40/50**
wiki:
![image](https://github.com/user-attachments/assets/2bfafe09-bd9f-4f1e-8a50-2ede6c6ac243)
app:
![image](https://github.com/user-attachments/assets/c492f974-0e47-413b-9e10-27c7fcb59575)

**- lvl 80/90**
wiki:
![image](https://github.com/user-attachments/assets/eb98886d-a792-4001-a339-7b9d30c34269)
app:
![image](https://github.com/user-attachments/assets/845c2d56-67a1-409e-9554-b13d711ca327)

**Reasoning :**
To ensure consistency and maintainability, I chose to change the way the base statistics were calculated. This approach simplifies handling cases for both Travelers, a method I found more comfortable and maintainable.
We are avoiding anti pattern code (i.e. redundant "if" conditions for handling both Travelers stats calculations as I did in the Sword of descension bug https://github.com/gridhead/gi-loadouts/pull/232)

**Future Considerations :**

- In the future, if another character faces a similar situation as both Travelers, we could handle it through simple inheritance from the MainCharacter class.

- Another approach worth exploring would be changing the rarity of Aether and Lumine to 4 stars while still displaying them as 5 stars in the UI.
