### PR TITLE
Stage the release v0.1.6 for Genshin Impact v5.4 Phase 1

### DIFF
--- a/gi_loadouts/__init__.py
+++ b/gi_loadouts/__init__.py
@@ -3,8 +3,8 @@ from importlib.metadata import metadata
 __metadict__ = metadata("gi-loadouts").json
 __versdata__ = __metadict__.get("version")
 
-__gicompat_vers__ = "5.3"
-__gicompat_part__ = "2"
+__gicompat_vers__ = "5.4"
+__gicompat_part__ = "1"
 
 __donation__ = "https://github.com/sponsors/gridhead"
 __releases__ = "https://github.com/gridhead/gi-loadouts/releases"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gi-loadouts"
-version = "0.1.5"
+version = "0.1.6"
 description = "Loadouts for Genshin Impact"
 authors = ["Akashdeep Dhar <akashdeep.dhar@gmail.com>", "Avadhoot Dhere <avadhootd99@gmail.com>", "Dhruv Bhirud <bhiruddhruv@gmail.com>", "Prithviraj Chavan <prithvichavan56110@gmail.com>", "Shounak Dey <shounakdey@ymail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Stage the release v0.1.6 for Genshin Impact v5.4 Phase 1

![Screenshot From 2025-02-17 01-39-14](https://github.com/user-attachments/assets/1f7231dd-f799-43fb-a1ca-029e0d46a7e5)
![Screenshot From 2025-02-17 01-39-04](https://github.com/user-attachments/assets/d2f930c2-d45f-40cb-a9ef-6963747c51e5)
