### PR TITLE
Stage the release v0.1.7 for Genshin Impact v5.5 Phase 1

### DIFF
--- a/gi_loadouts/__init__.py
+++ b/gi_loadouts/__init__.py
@@ -3,7 +3,7 @@ from importlib.metadata import metadata
 __metadict__ = metadata("gi-loadouts").json
 __versdata__ = __metadict__.get("version")
 
-__gicompat_vers__ = "5.4"
+__gicompat_vers__ = "5.5"
 __gicompat_part__ = "1"
 
 __donation__ = "https://github.com/sponsors/gridhead"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gi-loadouts"
-version = "0.1.6"
+version = "0.1.7"
 description = "Loadouts for Genshin Impact"
 authors = ["Akashdeep Dhar <akashdeep.dhar@gmail.com>", "Avadhoot Dhere <avadhootd99@gmail.com>", "Dhruv Bhirud <bhiruddhruv@gmail.com>", "Prithviraj Chavan <prithvichavan56110@gmail.com>", "Shounak Dey <shounakdey@ymail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Stage the release v0.1.7 for Genshin Impact v5.4 Phase 1

![Screenshot From 2025-03-28 00-20-37](https://github.com/user-attachments/assets/b06f3701-16af-46b0-a56e-ad0cbae4d36d)
![Screenshot From 2025-03-28 00-20-43](https://github.com/user-attachments/assets/17935a88-894b-4948-8f29-ee449422673b)
