### PR TITLE
Correct the mistaken image asset location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">Loadouts for Genshin Impact</h1>
 
 <p align="center">
-    <img src="https://raw.githubusercontent.com/gridhead/gi-loadouts/main/assets/imgs/pmon/8.png" alt="drawing" width="200"/>
+    <img src="https://raw.githubusercontent.com/gridhead/gi-loadouts/main/assets/imgs/pmon/8.webp" alt="drawing" width="200"/>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Correct the mistaken image asset location

Fixes whatever this is

![image](https://github.com/user-attachments/assets/b56e5fde-9284-4ba7-ab11-6d0d3db9012d)
