### PR TITLE
Change the format from `PNG` to `WEBP` in the  residual files

### DIFF
--- a/assets/info.ui
+++ b/assets/info.ui
@@ -71,7 +71,7 @@
     <string/>
    </property>
    <property name="pixmap">
-    <pixmap resource="pmon.qrc">:/pmon/imgs/pmon/8.png</pixmap>
+    <pixmap resource="pmon.qrc">:/pmon/imgs/pmon/8.webp</pixmap>
    </property>
    <property name="scaledContents">
     <bool>true</bool>

--- a/assets/lcns.ui
+++ b/assets/lcns.ui
@@ -71,7 +71,7 @@
     <string/>
    </property>
    <property name="pixmap">
-    <pixmap resource="pmon.qrc">:/pmon/imgs/pmon/8.png</pixmap>
+    <pixmap resource="pmon.qrc">:/pmon/imgs/pmon/8.webp</pixmap>
    </property>
    <property name="scaledContents">
     <bool>true</bool>

--- a/assets/wind.ui
+++ b/assets/wind.ui
@@ -761,7 +761,7 @@
        <string/>
       </property>
       <property name="pixmap">
-       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/fwol.png</pixmap>
+       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/fwol.webp</pixmap>
       </property>
       <property name="scaledContents">
        <bool>true</bool>
@@ -1446,7 +1446,7 @@
        <string/>
       </property>
       <property name="pixmap">
-       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/pmod.png</pixmap>
+       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/pmod.webp</pixmap>
       </property>
       <property name="scaledContents">
        <bool>true</bool>
@@ -2131,7 +2131,7 @@
        <string/>
       </property>
       <property name="pixmap">
-       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/sdoe.png</pixmap>
+       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/sdoe.webp</pixmap>
       </property>
       <property name="scaledContents">
        <bool>true</bool>
@@ -2816,7 +2816,7 @@
        <string/>
       </property>
       <property name="pixmap">
-       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/gboe.png</pixmap>
+       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/gboe.webp</pixmap>
       </property>
       <property name="scaledContents">
        <bool>true</bool>
@@ -3701,7 +3701,7 @@
        <string/>
       </property>
       <property name="pixmap">
-       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/ccol.png</pixmap>
+       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/ccol.webp</pixmap>
       </property>
       <property name="scaledContents">
        <bool>true</bool>
@@ -3784,7 +3784,7 @@
        <string/>
       </property>
       <property name="pixmap">
-       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/ccol.png</pixmap>
+       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/ccol.webp</pixmap>
       </property>
       <property name="scaledContents">
        <bool>true</bool>
@@ -3867,7 +3867,7 @@
        <string/>
       </property>
       <property name="pixmap">
-       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/gboe.png</pixmap>
+       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/gboe.webp</pixmap>
       </property>
       <property name="scaledContents">
        <bool>true</bool>
@@ -4135,7 +4135,7 @@
        <string/>
       </property>
       <property name="pixmap">
-       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/sdoe.png</pixmap>
+       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/sdoe.webp</pixmap>
       </property>
       <property name="scaledContents">
        <bool>true</bool>
@@ -4403,7 +4403,7 @@
        <string/>
       </property>
       <property name="pixmap">
-       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/pmod.png</pixmap>
+       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/pmod.webp</pixmap>
       </property>
       <property name="scaledContents">
        <bool>true</bool>
@@ -4671,7 +4671,7 @@
        <string/>
       </property>
       <property name="pixmap">
-       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/fwol.png</pixmap>
+       <pixmap resource="arti.qrc">:/arti/imgs/arti/main/fwol.webp</pixmap>
       </property>
       <property name="scaledContents">
        <bool>true</bool>

--- a/gi_loadouts/face/info/info.py
+++ b/gi_loadouts/face/info/info.py
@@ -2,7 +2,7 @@
 ################################################################################
 ## Form generated from reading UI file 'info.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.7.2
+## Created by: Qt User Interface Compiler version 6.8.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/gi_loadouts/face/lcns/lcns.py
+++ b/gi_loadouts/face/lcns/lcns.py
@@ -2,7 +2,7 @@
 ################################################################################
 ## Form generated from reading UI file 'lcns.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.7.2
+## Created by: Qt User Interface Compiler version 6.8.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/gi_loadouts/face/scan/rule.py
+++ b/gi_loadouts/face/scan/rule.py
@@ -98,7 +98,7 @@ class Rule(QDialog, Ui_scan, Dialog):
             self.arti_type_name.setText(truncate_text(getattr(kind.value, self.dist[self.arti_dist.currentText().strip()]["part"]).__name__, 34))
             self.arti_head_icon.setPixmap(QPixmap(f":arti/imgs/arti/{kind.value.file}/{self.dist[self.arti_dist.currentText().strip()]["part"]}.webp"))
             if self.arti_type.currentText().strip() == "None":
-                self.arti_head_icon.setPixmap(QPixmap(f":arti/imgs/arti/main/{self.dist[self.arti_dist.currentText().strip()]["part"]}.png"))
+                self.arti_head_icon.setPixmap(QPixmap(f":arti/imgs/arti/main/{self.dist[self.arti_dist.currentText().strip()]["part"]}.webp"))
 
     def change_levels_backdrop_by_changing_rarity(self) -> None:
         """

--- a/gi_loadouts/face/scan/scan.py
+++ b/gi_loadouts/face/scan/scan.py
@@ -2,7 +2,7 @@
 ################################################################################
 ## Form generated from reading UI file 'scan.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.8.0
+## Created by: Qt User Interface Compiler version 6.8.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/gi_loadouts/face/wind/rule.py
+++ b/gi_loadouts/face/wind/rule.py
@@ -217,7 +217,7 @@ class Rule(QMainWindow, Ui_mainwind, Facility, Assess):
             artiname.setText(truncate_text(getattr(kind.value, part).__name__, 32))
             headicon.setPixmap(QPixmap(f":arti/imgs/arti/{kind.value.file}/{part}.webp"))
             if droptype.currentText().strip() == "None":
-                headicon.setPixmap(QPixmap(f":arti/imgs/arti/main/{part}.png"))
+                headicon.setPixmap(QPixmap(f":arti/imgs/arti/main/{part}.webp"))
 
     def change_data_by_changing_level_or_stat(self, droplevl: QComboBox, droptype: QComboBox, droprare: QComboBox, dropstat: QComboBox, statdata: QLineEdit, part: str) -> None:
         """


### PR DESCRIPTION
Change the format from `PNG` to `WEBP` in the  residual files

 - Changed the asset file referencing in `ui` files
 - Changed the asset file referencing in codebase
 - Regenerated the binaries

Fixes: #251