### PR TITLE
Setup a `TAB` cadence for more keyboard-friendly navigation workflow

### DIFF
--- a/gi_loadouts/face/scan/__init__.py
+++ b/gi_loadouts/face/scan/__init__.py
@@ -86,3 +86,41 @@ mainstat = {
 }
 
 levliden = r"\+([0-9]|1[0-9]|20)\b"
+
+# List of widgets present in artifact information panel
+info_arti_widget = [
+    "arti_dist",
+    "arti_type",
+    "arti_levl",
+    "arti_rare",
+    "arti_name_main",
+    "arti_data_main",
+    "arti_name_a",
+    "arti_data_a",
+    "arti_name_b",
+    "arti_data_b",
+    "arti_name_c",
+    "arti_data_c",
+    "arti_name_d",
+    "arti_data_d"
+]
+
+# List of widgets present in return back panel
+back_arti_widget = [
+    "arti_back_done",
+    "arti_back_wipe"
+]
+
+# List of widgets present in right sidebar
+right_sidebar_widget = [
+    "arti_cnvs_load",
+    "arti_cnvs_conf",
+    "arti_cnvs_wipe"
+]
+
+# List of unpacked widgets arranged as per chronological `TAB` order
+tab_order_scan = [
+    *info_arti_widget,
+    *back_arti_widget,
+    *right_sidebar_widget
+]

--- a/gi_loadouts/face/scan/main.py
+++ b/gi_loadouts/face/scan/main.py
@@ -20,6 +20,7 @@ class ScanDialog(Rule):
         :return:
         """
         self.populate_dropdown()
+        self.regulate_taborder()
 
     def initialize_events(self) -> None:
         """

--- a/gi_loadouts/face/scan/rule.py
+++ b/gi_loadouts/face/scan/rule.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import QApplication, QComboBox, QDialog, QLineEdit, QMess
 
 from gi_loadouts import conf
 from gi_loadouts.data.arti import ArtiList
-from gi_loadouts.face.scan import areaiden
+from gi_loadouts.face.scan import areaiden, tab_order_scan
 from gi_loadouts.face.scan.file import file
 from gi_loadouts.face.scan.scan import Ui_scan
 from gi_loadouts.face.scan.work import ScanWorker
@@ -436,3 +436,12 @@ class Rule(QDialog, Ui_scan, Dialog):
         :return:
         """
         self.arti_shot.setText("<html><head/><body><p align=\"center\"><span style=\" font-size:16pt;\">YOUR ARTIFACT SCREENSHOT WILL SHOW UP HERE</span></p><p align=\"center\">INSERT AN ARTIFACT SCREENSHOT HERE BY EITHER PRESSING<span style=\" font-weight:700;\"> CTRL + V</span> OR USING <span style=\" font-weight:700;\">DRAG AND DROP</span></p></body></html>")
+
+    def regulate_taborder(self) -> None:
+        """
+        Set the tab order
+
+        :return:
+        """
+        for current_widget, next_widget in zip(tab_order_scan, tab_order_scan[1:]):
+             self.setTabOrder(getattr(self, current_widget), getattr(self, next_widget))

--- a/gi_loadouts/face/wind/__init__.py
+++ b/gi_loadouts/face/wind/__init__.py
@@ -1,0 +1,168 @@
+# List of widgets present in left sidebar
+sidebar_left_widget = [
+    "side_head",
+    "side_tckt",
+    "side_cash",
+    "side_lcns",
+    "side_info"
+]
+
+# List of widgets present in character information panel
+info_char_widget = [
+    "head_char_elem",
+    "head_char_name",
+    "head_char_cons",
+    "head_char_levl",
+    "head_char_data_attk",
+    "head_char_data_dfns",
+    "head_char_data_hlpt",
+    "head_char_data_subs",
+    "char_head_lumi",
+    "char_head_aeth"
+]
+
+# List of widgets present in artifact set information panel
+info_team_widget = [
+    "pair_area_desc",
+    "quad_area_desc",
+    "head_scan",
+    "head_load",
+    "head_save",
+    "head_wipe"
+]
+
+# List of widgets present in `Flower of Life` artifact information panel
+info_arti_fwol_widget = [
+    "arti_fwol_type",
+    "arti_fwol_levl",
+    "arti_fwol_rare",
+    "arti_fwol_name_main",
+    "arti_fwol_data_main",
+    "arti_fwol_name_a",
+    "arti_fwol_data_a",
+    "arti_fwol_name_b",
+    "arti_fwol_data_b",
+    "arti_fwol_name_c",
+    "arti_fwol_data_c",
+    "arti_fwol_name_d",
+    "arti_fwol_data_d",
+    "arti_fwol_scan",
+    "arti_fwol_load",
+    "arti_fwol_save",
+    "arti_fwol_wipe"
+]
+
+# List of widgets present in `Plume of Death` artifact information panel
+info_arti_pmod_widget = [
+    "arti_pmod_type",
+    "arti_pmod_levl",
+    "arti_pmod_rare",
+    "arti_pmod_name_main",
+    "arti_pmod_data_main",
+    "arti_pmod_name_a",
+    "arti_pmod_data_a",
+    "arti_pmod_name_b",
+    "arti_pmod_data_b",
+    "arti_pmod_name_c",
+    "arti_pmod_data_c",
+    "arti_pmod_name_d",
+    "arti_pmod_data_d",
+    "arti_pmod_scan",
+    "arti_pmod_load",
+    "arti_pmod_save",
+    "arti_pmod_wipe"
+]
+
+# List of widgets present in `Sands of Eon` artifact information panel
+info_arti_sdoe_widget = [
+    "arti_sdoe_type",
+    "arti_sdoe_levl",
+    "arti_sdoe_rare",
+    "arti_sdoe_name_main",
+    "arti_sdoe_data_main",
+    "arti_sdoe_name_a",
+    "arti_sdoe_data_a",
+    "arti_sdoe_name_b",
+    "arti_sdoe_data_b",
+    "arti_sdoe_name_c",
+    "arti_sdoe_data_c",
+    "arti_sdoe_name_d",
+    "arti_sdoe_data_d",
+    "arti_sdoe_scan",
+    "arti_sdoe_load",
+    "arti_sdoe_save",
+    "arti_sdoe_wipe"
+]
+
+# List of widgets present in `Goblet of Eonothem` artifact information panel
+info_arti_gboe_widget = [
+    "arti_gboe_type",
+    "arti_gboe_levl",
+    "arti_gboe_rare",
+    "arti_gboe_name_main",
+    "arti_gboe_data_main",
+    "arti_gboe_name_a",
+    "arti_gboe_data_a",
+    "arti_gboe_name_b",
+    "arti_gboe_data_b",
+    "arti_gboe_name_c",
+    "arti_gboe_data_c",
+    "arti_gboe_name_d",
+    "arti_gboe_data_d",
+    "arti_gboe_scan",
+    "arti_gboe_load",
+    "arti_gboe_save",
+    "arti_gboe_wipe"
+]
+
+# List of widgets present in `Circlet of Logos` artifact information panel
+info_arti_ccol_widget = [
+    "arti_ccol_type",
+    "arti_ccol_levl",
+    "arti_ccol_rare",
+    "arti_ccol_name_main",
+    "arti_ccol_data_main",
+    "arti_ccol_name_a",
+    "arti_ccol_data_a",
+    "arti_ccol_name_b",
+    "arti_ccol_data_b",
+    "arti_ccol_name_c",
+    "arti_ccol_data_c",
+    "arti_ccol_name_d",
+    "arti_ccol_data_d",
+    "arti_ccol_scan",
+    "arti_ccol_load",
+    "arti_ccol_save",
+    "arti_ccol_wipe"
+]
+
+# List of widgets present in weapon information panel
+info_weap_widget = [
+    "weap_area_type",
+    "weap_area_name",
+    "weap_area_refn",
+    "weap_area_levl",
+    "weap_area_batk",
+    "weap_area_stat",
+    "weap_head_load",
+    "weap_head_save"
+]
+
+# List of widgets present in weapon refinements information panel
+info_refn_widget = [
+    "weap_area_refn_body"
+]
+
+# List of unpacked widgets arranged as per chronological `TAB` order
+tab_order_wind = [
+    *sidebar_left_widget,
+    *info_char_widget,
+    *info_team_widget,
+    *info_arti_fwol_widget,
+    *info_arti_pmod_widget,
+    *info_arti_sdoe_widget,
+    *info_arti_gboe_widget,
+    *info_arti_ccol_widget,
+    *info_weap_widget,
+    *info_refn_widget
+]

--- a/gi_loadouts/face/wind/main.py
+++ b/gi_loadouts/face/wind/main.py
@@ -52,6 +52,7 @@ class MainWindow(Rule):
             self.change_data_by_changing_level_or_stat(item[0], item[1], item[2], item[3], item[4], item[5])
             self.change_artifact_substats_by_changing_rarity_or_mainstat(item[2], item[3], item[5])
             self.change_levels_backdrop_by_changing_rarity(item[0], item[8], item[2])
+        self.regulate_taborder()
         self.statarea.showMessage("Ready.")
 
     def initialize_events(self) -> None:

--- a/gi_loadouts/face/wind/rule.py
+++ b/gi_loadouts/face/wind/rule.py
@@ -10,6 +10,7 @@ from gi_loadouts.face.lcns.main import LcnsDialog
 from gi_loadouts.face.otpt.main import OtptWindow
 from gi_loadouts.face.scan.main import ScanDialog
 from gi_loadouts.face.util import modify_graphics_resource, truncate_text
+from gi_loadouts.face.wind import tab_order_wind
 from gi_loadouts.face.wind.calc import Assess
 from gi_loadouts.face.wind.fclt import Facility
 from gi_loadouts.face.wind.util import show_status
@@ -503,3 +504,12 @@ class Rule(QMainWindow, Ui_mainwind, Facility, Assess):
         :return:
         """
         QDesktopServices.openUrl(QUrl(link))
+
+    def regulate_taborder(self) -> None:
+        """
+        Set the tab order
+
+        :return:
+        """
+        for current_widget, next_widget in zip(tab_order_wind, tab_order_wind[1:]):
+             self.setTabOrder(getattr(self, current_widget), getattr(self, next_widget))


### PR DESCRIPTION
Setup a `TAB` cadence for more keyboard-friendly navigation workflow

- List out all the widgets used in main and scan window
- Use `setTabOrder` to set the order of `TAB` for those widgets

Fixes: #53 