### PR TITLE
Update GitHub `workflow` to use latest version of `Fedora` for testing code functionality

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           - tox-env: "py312-dist"
             container: "fedora:40"
           - tox-env: "py313-dist"
-            container: "fedora:41"
+            container: "fedora:42"
 
     container: ${{ matrix.container }}
 


### PR DESCRIPTION
Update GitHub `workflow` to use latest version of `Fedora` for testing code functionality

Fixes: #320 