### PR TITLE
Check validity first before loading `artifact` from the file

### DIFF
--- a/gi_loadouts/face/wind/fclt.py
+++ b/gi_loadouts/face/wind/fclt.py
@@ -196,8 +196,6 @@ class Facility(Dialog):
                     dropname.setCurrentText(getattr(arti, f"stat_{indx}").stat_name.value)
                     if indx != "main":
                         dropdata.setText(str(getattr(arti, f"stat_{indx}").stat_data))
-                else:
-                    raise ValueError("Artifact stat cannot be identified.")
 
             show_status(self.statarea, "Artifact data has been successfully loaded.")
 
@@ -250,8 +248,6 @@ class Facility(Dialog):
                         dropname.setCurrentText(getattr(arti, f"stat_{indx}").stat_name.value)
                         if indx != "main":
                             dropdata.setText(str(getattr(arti, f"stat_{indx}").stat_data))
-                    else:
-                        raise ValueError("Artifact stat cannot be identified.")
 
             show_status(self.statarea, "Artifact set has been successfully loaded.")
 

--- a/gi_loadouts/type/file/arti.py
+++ b/gi_loadouts/type/file/arti.py
@@ -129,7 +129,11 @@ def make_artifile_from_yaml(objc: dict) -> ArtiFile:
             stat_d=ATTR(stat_name=__revmap__[objc["stat"]["d"]["name"]], stat_data=objc["stat"]["d"]["data"]),
         )
     except Exception as expt:
-        raise ValueError("Artifact unit data cannot be parsed.") from expt
+        raise ValueError("Artifact stat cannot be identified or unit data cannot be parsed.") from expt
+
+    for indx in ["a", "b", "c", "d"]:
+        if artiobjc.stat_main.stat_name == getattr(artiobjc, f"stat_{indx}").stat_name:
+            raise ValueError("Artifact substat matches main stat.")
     return artiobjc
 
 
@@ -160,5 +164,9 @@ def make_artifile_from_good(objc: dict) -> ArtiFile:
             setattr(artiobjc, f"stat_{alfalist[0]}", ATTR(stat_name=__stat_good_revmap__[item["key"]], stat_data=item["value"]))
             alfalist.pop(0)
     except Exception as expt:
-        raise ValueError("Artifact unit data cannot be parsed.") from expt
+        raise ValueError("Artifact stat cannot be identified or unit data cannot be parsed.") from expt
+
+    for indx in ["a", "b", "c", "d"]:
+        if artiobjc.stat_main.stat_name == getattr(artiobjc, f"stat_{indx}").stat_name:
+            raise ValueError("Artifact substat matches main stat.")
     return artiobjc

--- a/test/face/wind/arti/test_arti_file.py
+++ b/test/face/wind/arti/test_arti_file.py
@@ -322,23 +322,23 @@ def test_arti_load_awry(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture,
     assert runner.dialog.icon() == QMessageBox.Information
     assert runner.dialog.windowTitle() == "Load failed"
     assert "Please confirm that the artifact data follows the valid format before loading it from a location that is accessible." in runner.dialog.text()
-    assert "Artifact unit data cannot be parsed." in runner.dialog.text()
+    assert "Artifact stat cannot be identified or unit data cannot be parsed." in runner.dialog.text()
     assert runner.dialog.isVisible()
 
 
 @pytest.mark.parametrize(
     "area, sample, type",
     [
-        pytest.param("fwol", yaml_fwol_sample.replace("name: Crit Rate\n", "name: HP\n"), yaml_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Flower of Life' area from YAML data"),
-        pytest.param("pmod", yaml_pmod_sample.replace("name: DEF\n", "name: ATK\n"), yaml_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Plume of Death' area from YAML data"),
-        pytest.param("sdoe", yaml_sdoe_sample.replace("name: ATK\n", "name: Elemental Mastery\n"), yaml_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Sands of Eon' area from YAML data"),
-        pytest.param("gboe", yaml_gboe_sample.replace("name: Elemental Mastery\n", "name: Physical DMG Bonus\n"), yaml_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Goblet of Eonothem' area from YAML data"),
-        pytest.param("ccol", yaml_ccol_sample.replace("name: ATK\n", "name: Healing Bonus\n"), yaml_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Circlet of Logos' area from YAML data"),
-        pytest.param("fwol", json_fwol_sample.replace("\"key\": \"critRate_\",\n", "\"key\": \"hp\",\n"), json_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Flower of Life' area from JSON data"),
-        pytest.param("pmod", json_pmod_sample.replace("\"key\": \"def\",\n", "\"key\": \"atk\",\n"), json_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Plume of Death' area from JSON data"),
-        pytest.param("sdoe", json_sdoe_sample.replace("\"key\": \"atk\",\n", "\"key\": \"eleMas\",\n"), json_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Sands of Eon' area from JSON data"),
-        pytest.param("gboe", json_gboe_sample.replace("\"key\": \"eleMas\",\n", "\"key\": \"physical_dmg_\",\n"), json_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Goblet of Eonothem' area from JSON data"),
-        pytest.param("ccol", json_ccol_sample.replace("\"key\": \"atk\",\n", "\"key\": \"heal_\",\n"), json_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Circlet of Logos' area from JSON data"),
+        pytest.param("fwol", yaml_fwol_sample.replace("name: Crit Rate\n", "name: Foo Bar\n"), yaml_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Flower of Life' area from YAML data"),
+        pytest.param("pmod", yaml_pmod_sample.replace("name: DEF\n", "name: Foo Bar\n"), yaml_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Plume of Death' area from YAML data"),
+        pytest.param("sdoe", yaml_sdoe_sample.replace("name: ATK\n", "name: Foo Bar\n"), yaml_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Sands of Eon' area from YAML data"),
+        pytest.param("gboe", yaml_gboe_sample.replace("name: Elemental Mastery\n", "name: Foo Bar\n"), yaml_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Goblet of Eonothem' area from YAML data"),
+        pytest.param("ccol", yaml_ccol_sample.replace("name: ATK\n", "name: Foo Bar\n"), yaml_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Circlet of Logos' area from YAML data"),
+        pytest.param("fwol", json_fwol_sample.replace("\"key\": \"critRate_\",\n", "\"key\": \"foobar\",\n"), json_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Flower of Life' area from JSON data"),
+        pytest.param("pmod", json_pmod_sample.replace("\"key\": \"def\",\n", "\"key\": \"foobar\",\n"), json_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Plume of Death' area from JSON data"),
+        pytest.param("sdoe", json_sdoe_sample.replace("\"key\": \"atk\",\n", "\"key\": \"foobar\",\n"), json_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Sands of Eon' area from JSON data"),
+        pytest.param("gboe", json_gboe_sample.replace("\"key\": \"eleMas\",\n", "\"key\": \"foobar\",\n"), json_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Goblet of Eonothem' area from JSON data"),
+        pytest.param("ccol", json_ccol_sample.replace("\"key\": \"atk\",\n", "\"key\": \"foobar\",\n"), json_type, id="face.wind.rule: Loading an artifact with incorrect substats into 'Circlet of Logos' area from JSON data"),
     ]
 )
 def test_arti_load_name(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture, area: str, sample: str, type: str) -> None:
@@ -361,7 +361,46 @@ def test_arti_load_name(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture,
     assert runner.dialog.icon() == QMessageBox.Information
     assert runner.dialog.windowTitle() == "Load failed"
     assert "Please confirm that the artifact data follows the valid format before loading it from a location that is accessible." in runner.dialog.text()
-    assert "Artifact stat cannot be identified." in runner.dialog.text()
+    assert "Artifact stat cannot be identified or unit data cannot be parsed." in runner.dialog.text()
+    assert runner.dialog.isVisible()
+
+
+@pytest.mark.parametrize(
+    "area, sample, type",
+    [
+        pytest.param("fwol", yaml_fwol_sample.replace("name: Crit Rate\n", "name: HP\n"), yaml_type, id="face.wind.rule: Loading an artifact with same substat and mainstat into 'Flower of Life' area from YAML data"),
+        pytest.param("pmod", yaml_pmod_sample.replace("name: DEF\n", "name: ATK\n"), yaml_type, id="face.wind.rule: Loading an artifact with same substat and mainstat into 'Plume of Death' area from YAML data"),
+        pytest.param("sdoe", yaml_sdoe_sample.replace("name: ATK\n", "name: Elemental Mastery\n"), yaml_type, id="face.wind.rule: Loading an artifact with same substat and mainstat into 'Sands of Eon' area from YAML data"),
+        pytest.param("gboe", yaml_gboe_sample.replace("name: Elemental Mastery\n", "name: ATK %\n").replace("name: Physical DMG Bonus\n", "name: ATK %\n"), yaml_type, id="face.wind.rule: Loading an artifact with same substat and mainstat into 'Goblet of Eonothem' area from YAML data"),
+        pytest.param("ccol", yaml_ccol_sample.replace("name: ATK\n", "name: HP\n").replace("name: Healing Bonus\n", "name: HP\n"), yaml_type, id="face.wind.rule: Loading an artifact with same substat and mainstat into 'Circlet of Logos' area from YAML data"),
+        pytest.param("fwol", json_fwol_sample.replace("\"key\": \"critRate_\",\n", "\"key\": \"hp\",\n"), json_type, id="face.wind.rule: Loading an artifact with same substat and mainstat into 'Flower of Life' area from JSON data"),
+        pytest.param("pmod", json_pmod_sample.replace("\"key\": \"def\",\n", "\"key\": \"atk\",\n"), json_type, id="face.wind.rule: Loading an artifact with same substat and mainstat into 'Plume of Death' area from JSON data"),
+        pytest.param("sdoe", json_sdoe_sample.replace("\"key\": \"atk\",\n", "\"key\": \"eleMas\",\n"), json_type, id="face.wind.rule: Loading an artifact with same substat and mainstat into 'Sands of Eon' area from JSON data"),
+        pytest.param("gboe", json_gboe_sample.replace("\"key\": \"eleMas\",\n", "\"key\": \"atk_\",\n").replace("\"mainStatKey\": \"physical_dmg_\",\n", "\"mainStatKey\": \"atk_\",\n"), json_type, id="face.wind.rule: Loading an artifact with same substat and mainstat into 'Goblet of Eonothem' area from JSON data"),
+        pytest.param("ccol", json_ccol_sample.replace("\"key\": \"atk\",\n", "\"key\": \"hp\",\n").replace("\"mainStatKey\": \"heal_\",\n", "\"mainStatKey\": \"hp\",\n"), json_type, id="face.wind.rule: Loading an artifact with same substat and mainstat into 'Circlet of Logos' area from JSON data"),
+    ]
+)
+def test_arti_load_same(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture, area: str, sample: str, type: str) -> None:
+    """
+    Test loading an artifact with same substat and mainstat across five areas from data
+
+    :return:
+    """
+
+    """
+    Perform the action of saving the artifact information
+    """
+    mocker.patch.object(file.FileHandling, "load", return_value=(True, sample, type))
+    qtbot.mouseClick(getattr(runner, f"arti_{area}_load"), Qt.LeftButton)
+
+    """
+    Confirm if the user interface elements change accordingly
+    """
+    assert isinstance(runner.dialog, QMessageBox)
+    assert runner.dialog.icon() == QMessageBox.Information
+    assert runner.dialog.windowTitle() == "Load failed"
+    assert "Please confirm that the artifact data follows the valid format before loading it from a location that is accessible." in runner.dialog.text()
+    assert "Artifact substat matches main stat." in runner.dialog.text()
     assert runner.dialog.isVisible()
 
 

--- a/test/face/wind/team/test_team_file.py
+++ b/test/face/wind/team/test_team_file.py
@@ -309,21 +309,21 @@ def test_team_load_awry(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture,
     [
         pytest.param(
             yaml_sample.
-            replace("name: Crit Rate\n", "name: HP\n").
-            replace("name: DEF\n", "name: ATK\n").
-            replace("name: ATK\n", "name: Elemental Mastery\n").
-            replace("name: Elemental Mastery\n", "name: Physical DMG Bonus\n").
-            replace("name: ATK\n", "name: Healing Bonus\n"),
+            replace("name: Crit Rate\n", "name: Foo Bar\n").
+            replace("name: DEF\n", "name: Foo Bar\n").
+            replace("name: ATK\n", "name: Foo Bar\n").
+            replace("name: Elemental Mastery\n", "name: Foo Bar\n").
+            replace("name: ATK\n", "name: Foo Bar\n"),
             yaml_type,
             id="face.wind.rule: Loading an artifact with incorrect substats from YAML data"
         ),
         pytest.param(
             json_sample.
-            replace("\"key\": \"critRate_\",\n", "\"key\": \"hp\",\n").
-            replace("\"key\": \"def\",\n", "\"key\": \"atk\",\n").
-            replace("\"key\": \"atk\",\n", "\"key\": \"eleMas\",\n").
-            replace("\"key\": \"eleMas\",\n", "\"key\": \"physical_dmg_\",\n").
-            replace("\"key\": \"atk\",\n", "\"key\": \"heal_\",\n"),
+            replace("\"key\": \"critRate_\",\n", "\"key\": \"foobar\",\n").
+            replace("\"key\": \"def\",\n", "\"key\": \"foobar\",\n").
+            replace("\"key\": \"atk\",\n", "\"key\": \"foobar\",\n").
+            replace("\"key\": \"eleMas\",\n", "\"key\": \"foobar\",\n").
+            replace("\"key\": \"atk\",\n", "\"key\": \"foobar\",\n"),
             json_type,
             id="face.wind.rule: Loading an artifact with incorrect substats from JSON data"
         ),
@@ -349,7 +349,7 @@ def test_team_load_name(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture,
     assert runner.dialog.icon() == QMessageBox.Information
     assert runner.dialog.windowTitle() == "Load failed"
     assert "Please confirm that the artifact set follows the valid format before loading it from a location that is accessible." in runner.dialog.text()
-    assert "Artifact stat cannot be identified." in runner.dialog.text()
+    assert "Artifact set data cannot be parsed." in runner.dialog.text()
     assert runner.dialog.isVisible()
 
 


### PR DESCRIPTION
The change in this PR fix: #166 

<hr>

The change now first compares the main stat name with sub stat name and if they matches, it raises exception and if they do not match then the general flow continues.

Below files can be used to test the new changes:
Single Artifact
```yaml
area: FWOL
levl: Level 00
name: Snowswept Memory
rare: 4
stat:
  a:
    data: 1.0
    name: ATK
  b:
    data: 1.0
    name: HP
  c:
    data: 1.0
    name: ATK
  d:
    data: 1.0
    name: HP
  main:
    data: 645.0
    name: HP
type: Blizzard Strayer
```
Artifact Set
```yaml
ccol:
  area: CCOL
  levl: Level 20
  name: Capricious Visage
  rare: 5
  stat:
    a:
      data: 31.0
      name: ATK
    b:
      data: 11.7
      name: DEF %
    c:
      data: 10.5
      name: ATK %
    d:
      data: 13.2
      name: Crit DMG
    main:
      data: 31.1
      name: Crit Rate
  type: Shimenawa's Reminiscence
fwol:
  area: FWOL
  levl: Level 20
  name: Gladiator's Nostalgia
  rare: 5
  stat:
    a:
      data: 28.8
      name: Crit DMG
    b:
      data: 7.4
      name: Crit Rate
    c:
      data: 5.2
      name: Energy Recharge
    d:
      data: 16.0
      name: DEF
    main:
      data: 4780.0
      name: HP
  type: Gladiator's Finale
gboe:
  area: GBOE
  levl: Level 20
  name: Goblet of Chiseled Crag
  rare: 5
  stat:
    a:
      data: 538.0
      name: HP
    b:
      data: 11.7
      name: Crit Rate
    c:
      data: 19.0
      name: Elemental Mastery
    d:
      data: 19.0
      name: ATK
    main:
      data: 46.6
      name: Pyro DMG Bonus
  type: Archaic Petra
pmod:
  area: PMOD
  levl: Level 20
  name: Royal Plume
  rare: 5
  stat:
    a:
      data: 5.8
      name: ATK %
    b:
      data: 40.0
      name: Elemental Mastery
    c:
      data: 12.1
      name: Crit Rate
    d:
      data: 13.2
      name: Crit DMG
    main:
      data: 311.0
      name: ATK
  type: Noblesse Oblige
sdoe:
  area: SDOE
  levl: Level 20
  name: Copper Compass
  rare: 5
  stat:
    a:
      data: 21.0
      name: ATK %
    b:
      data: 31.0
      name: ATK
    c:
      data: 5.4
      name: Crit Rate
    d:
      data: 299.0
      name: HP
    main:
      data: 46.6
      name: ATK %
  type: Heart of Depth
```

![image](https://github.com/user-attachments/assets/e7b6fcb8-8ded-446a-a475-04de2d9960e2)
