### PR TITLE
Use absolute import instead of relative import in `main.py`

### DIFF
--- a/gi_loadouts/main.py
+++ b/gi_loadouts/main.py
@@ -4,8 +4,12 @@ import sys
 from PySide6.QtGui import QFontDatabase
 from PySide6.QtWidgets import QApplication
 
-from .face import rsrc  # noqa: F401
-from .face.wind.main import MainWindow
+from gi_loadouts.face import rsrc  # noqa: F401
+from gi_loadouts.face.wind.main import MainWindow
+
+"""
+Uses absolute imports for PyInstaller compability
+"""
 
 
 def load_custom_font() -> None:


### PR DESCRIPTION
I used absolute imports instead of relative imports in `main.py` as direct script execution does not
provide a package context, which breaks functionality of running by tools like PyInstaller.

This PR will fix: #328 