### PR TITLE
Stage the release v0.1.8 for Genshin Impact v5.6 Phase 1

### DIFF
--- a/gi_loadouts/__init__.py
+++ b/gi_loadouts/__init__.py
@@ -3,7 +3,7 @@ from importlib.metadata import metadata
 __metadict__ = metadata("gi-loadouts").json
 __versdata__ = __metadict__.get("version")
 
-__gicompat_vers__ = "5.5"
+__gicompat_vers__ = "5.6"
 __gicompat_part__ = "1"
 
 __donation__ = "https://github.com/sponsors/gridhead"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gi-loadouts"
-version = "0.1.7"
+version = "0.1.8"
 description = "Loadouts for Genshin Impact"
 authors = ["Akashdeep Dhar <akashdeep.dhar@gmail.com>", "Avadhoot Dhere <avadhootd99@gmail.com>", "Dhruv Bhirud <bhiruddhruv@gmail.com>", "Prithviraj Chavan <prithvichavan56110@gmail.com>", "Shounak Dey <shounakdey@ymail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Stage the release v0.1.8 for Genshin Impact v5.6 Phase 1.

![Screenshot From 2025-05-08 00-40-50](https://github.com/user-attachments/assets/04b3bef3-9133-4577-9ce0-e2fc4201ebe1)
![Screenshot From 2025-05-08 00-40-57](https://github.com/user-attachments/assets/0b961fa3-032c-4cb1-a06d-b9f516b1da73)
![Screenshot From 2025-05-08 00-41-14](https://github.com/user-attachments/assets/764c37ac-ca20-449b-ba93-56f3106a0689)
