### PR TITLE
Stage the release v0.1.9 for Genshin Impact v5.7 Phase 1

### DIFF
--- a/gi_loadouts/__init__.py
+++ b/gi_loadouts/__init__.py
@@ -3,7 +3,7 @@ from importlib.metadata import metadata
 __metadict__ = metadata("gi-loadouts").json
 __versdata__ = __metadict__.get("version")
 
-__gicompat_vers__ = "5.6"
+__gicompat_vers__ = "5.7"
 __gicompat_part__ = "1"
 
 __donation__ = "https://github.com/sponsors/gridhead"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gi-loadouts"
-version = "0.1.8"
+version = "0.1.9"
 description = "Loadouts for Genshin Impact"
 authors = ["Akashdeep Dhar <akashdeep.dhar@gmail.com>", "Avadhoot Dhere <avadhootd99@gmail.com>", "Dhruv Bhirud <bhiruddhruv@gmail.com>", "Prithviraj Chavan <prithvichavan56110@gmail.com>", "Shounak Dey <shounakdey@ymail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Stage the release v0.1.9 for Genshin Impact v5.7 Phase 1.

![Screenshot From 2025-06-19 20-00-13](https://github.com/user-attachments/assets/20d537f7-38cc-4ab5-bf3c-5ec2b9f43601)
![Screenshot From 2025-06-19 20-00-17](https://github.com/user-attachments/assets/455ebaa6-1800-413b-ab44-0961cadc5667)
![Screenshot From 2025-06-19 20-08-34](https://github.com/user-attachments/assets/267e2d46-190e-47d8-b59f-3cd25d796403)
![Screenshot From 2025-06-19 20-08-41](https://github.com/user-attachments/assets/5610c772-456e-4afd-9950-8cb1a11ac2e9)
