### PR TITLE
Fix Claude workflow permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,9 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
+      checks: write
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,10 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
       actions: read
+      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Upgrade Claude workflows from deprecated `@beta` to stable `@v1` version
- Add missing `pull-requests: write` permission for commenting on PRs  
- Add missing `checks: write` permission for status checks

## Test plan
- [ ] Verify workflows pass syntax validation
- [ ] Test @claude mentions trigger workflow correctly
- [ ] Confirm Claude can comment on PRs and issues

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Update Claude GitHub Actions workflows to use the stable @v1 action and grant necessary write permissions for pull requests and status checks

Enhancements:
- Upgrade anthropics/claude-code-action from @beta to @v1 in both workflows
- Add pull-requests: write and checks: write permissions to enable PR commenting and status checks