### PR TITLE
Update renovate config to use exact commit message

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
     "extends": [
       "group:allNonMajor"
     ],
-    "commitMessageAction": "Automated dependency updates for GI Loadouts"
+    "commitMessage": "Automated dependency updates for GI Loadouts"
   },
   "automergeStrategy": "rebase",
   "rangeStrategy": "widen",


### PR DESCRIPTION
Update renovate config to use exact commit message

## Summary by Sourcery

Chores:
- Update renovate.json to enforce exact commit message convention