### PR TITLE
Correct base stat for character `Lauma`

### DIFF
--- a/gi_loadouts/data/char/lauma.py
+++ b/gi_loadouts/data/char/lauma.py
@@ -6,7 +6,8 @@ from ...type.weap import WeaponType
 
 
 class Lauma(Char):
-    __statdata__: dict = {0: 0.0, 1: 0.0, 2: 28.8, 3: 57.6, 4: 57.6, 5: 86.4, 6: 115.2}
+    # Lauma has 200 Elemental Mastery in her base statistics
+    __statdata__: dict = {0: 200.0, 1: 200.0, 2: 228.8, 3: 257.6, 4: 257.6, 5: 286.4, 6: 315.2}
     __statname__: STAT = STAT.elemental_mastery
     name: CharName = CharName.lauma
     rare: Rare = Rare.Star_5

--- a/test/data/test_char.py
+++ b/test/data/test_char.py
@@ -400,8 +400,8 @@ from test import verify_accuracy
         pytest.param(
             "Lauma", "catalyst", 5, "dendro", STAT.elemental_mastery,
             {
-                "Level 40/50 (Rank 2)": (4784.71, 114.49, 300.48, 28.8),
-                "Level 80/90 (Rank 6)": (9894.80, 236.82, 621.49, 115.2),
+                "Level 40/50 (Rank 2)": (4784.71, 114.49, 300.48, 228.8),
+                "Level 80/90 (Rank 6)": (9894.80, 236.82, 621.49, 315.2),
             }, id="data.char: Lauma",
         ),
         pytest.param(


### PR DESCRIPTION
This PR adds 200 base EM in `__statdata__` for every ascension phase and offsets the ascension stat accordingly.

<img width="1595" height="983" alt="Screenshot From 2025-09-22 16-35-08" src="https://github.com/user-attachments/assets/91e1443b-4434-44d3-a3ce-26e18ef93a32" />
<img width="1595" height="983" alt="Screenshot From 2025-09-22 16-34-40" src="https://github.com/user-attachments/assets/b7728d4a-4e42-4777-8b05-7c7b6c548d5a" />

This new version of Genshin Impact adds a lot of basic changes to the structure of in game characters. Hope its the last weird change.

Fixes: #436

## Summary by Sourcery

Fix Lauma’s base elemental mastery stat by adding a 200 EM base to each ascension phase and adjust the ascension offsets accordingly.

Bug Fixes:
- Correct Lauma’s __statdata__ to include a 200 base EM at all ascension levels and update the resulting elemental mastery values.

Tests:
- Update unit test expectations for Lauma’s elemental mastery at Level 40/50 and Level 80/90 to match the corrected stats.