### PR TITLE
Create the `v0.1.11` version release for Luna I (or Genshin Impact 6.0)

### DIFF
--- a/gi_loadouts/__init__.py
+++ b/gi_loadouts/__init__.py
@@ -3,8 +3,8 @@ from importlib.metadata import metadata
 __metadict__ = metadata("gi-loadouts").json
 __versdata__ = __metadict__.get("version")
 
-__gicompat_vers__ = "5.8"
-__gicompat_part__ = "1"
+__gicompat_vers__ = "6.0"
+__gicompat_part__ = "2"
 
 __donation__ = "https://github.com/sponsors/gridhead"
 __releases__ = "https://github.com/gridhead/gi-loadouts/releases"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gi-loadouts"
-version = "0.1.10"
+version = "0.1.11"
 description = "Loadouts for Genshin Impact"
 authors = ["Akashdeep Dhar <akashdeep.dhar@gmail.com>", "Avadhoot Dhere <avadhootd99@gmail.com>", "Dhruv Bhirud <bhiruddhruv@gmail.com>", "Prithviraj Chavan <prithvichavan56110@gmail.com>", "Shounak Dey <shounakdey@ymail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Create the `v0.1.11` version release for Luna I (or Genshin Impact 6.0)

## Summary by Sourcery

Prepare the v0.1.11 release by updating the package version and Genshin Impact compatibility metadata.

Build:
- Bump package version to 0.1.11 in pyproject.toml
- Update Genshin Impact compatibility to version 6.0 (part 2) in __init__.py