### PR TITLE
Stage the release v0.1.12 for Genshin Impact Luna II (v6.1 Phase 1)

### DIFF
--- a/gi_loadouts/__init__.py
+++ b/gi_loadouts/__init__.py
@@ -3,8 +3,8 @@ from importlib.metadata import metadata
 __metadict__ = metadata("gi-loadouts").json
 __versdata__ = __metadict__.get("version")
 
-__gicompat_vers__ = "6.0"
-__gicompat_part__ = "2"
+__gicompat_vers__ = "6.1"
+__gicompat_part__ = "1"
 
 __donation__ = "https://github.com/sponsors/gridhead"
 __releases__ = "https://github.com/gridhead/gi-loadouts/releases"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gi-loadouts"
-version = "0.1.11"
+version = "0.1.12"
 description = "Loadouts for Genshin Impact"
 authors = ["Akashdeep Dhar <akashdeep.dhar@gmail.com>", "Avadhoot Dhere <avadhootd99@gmail.com>", "Dhruv Bhirud <bhiruddhruv@gmail.com>", "Prithviraj Chavan <prithvichavan56110@gmail.com>", "Shounak Dey <shounakdey@ymail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Stage the release v0.1.12 for Genshin Impact Luna I (v6.1 Phase 1)

## Summary by Sourcery

Stage release v0.1.12 by bumping the package version and updating Genshin Impact compatibility to v6.1 Phase 1.

Enhancements:
- Update Genshin Impact compatibility to version 6.1 Part 1.

Build:
- Bump package version to 0.1.12 in pyproject.toml.