### PR TITLE
Stage the release v0.1.13 for Genshin Impact Luna III (v6.2 Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,10 +501,10 @@ ensure that the Tesseract OCR application is installed and configured properly.
 4.  Install the project dependencies using UV and start the application 
     software.
     ```
-    (venv) $ uv sync --extra dev
+    (venv) $ uv sync --active --extra dev
     ```
     ```
-    (venv) $ uv run gi-loadouts
+    (venv) $ uv run --active gi-loadouts
     ```
 
 #### On Microsoft Windows
@@ -538,10 +538,10 @@ ensure that the Tesseract OCR application is installed and configured properly.
 4.  Install the project dependencies using UV and start the application 
     software.
     ```
-    (venv) PS > uv sync --extra dev
+    (venv) PS > uv sync --active --extra dev
     ```
     ```
-    (venv) PS > uv run gi-loadouts
+    (venv) PS > uv run --active gi-loadouts
     ```
 
 ## Contribution

--- a/gi_loadouts/__init__.py
+++ b/gi_loadouts/__init__.py
@@ -3,8 +3,8 @@ from importlib.metadata import metadata
 __metadict__ = metadata("gi-loadouts").json
 __versdata__ = __metadict__.get("version")
 
-__gicompat_vers__ = "6.1"
-__gicompat_part__ = "1"
+__gicompat_vers__ = "6.2"
+__gicompat_part__ = "2"
 
 __donation__ = "https://github.com/sponsors/gridhead"
 __releases__ = "https://github.com/gridhead/gi-loadouts/releases"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gi-loadouts"
-version = "0.1.12"
+version = "0.1.13"
 description = "Loadouts for Genshin Impact"
 authors = [
     {name = "Akashdeep Dhar", email = "akashdeep.dhar@gmail.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -150,7 +150,7 @@ wheels = [
 
 [[package]]
 name = "gi-loadouts"
-version = "0.1.12"
+version = "0.1.13"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
Stage the release v0.1.13 for Genshin Impact Luna III (v6.2 Phase 2)

## Summary by Sourcery

Stage the v0.1.13 release of gi-loadouts with updated Genshin Impact compatibility and usage instructions.

Enhancements:
- Update internal Genshin Impact compatibility metadata to version 6.2 phase 2.
- Bump project version from 0.1.12 to 0.1.13 for the new release.

Documentation:
- Update README setup instructions to use the active environment with uv sync and uv run commands.