### PR TITLE
Remove the conditional substat calculation of weapon `Harbinger of Dawn`

### DIFF
--- a/gi_loadouts/data/weap/swords/hbod.py
+++ b/gi_loadouts/data/weap/swords/hbod.py
@@ -18,11 +18,4 @@ class HarbingerofDawn(Sword):
         "When HP is above 90%, increases CRIT Rate by 24.5%.",
         "When HP is above 90%, increases CRIT Rate by 28%.",
     ]
-    refi_stat: list[WeaponStat] = [
-        [WeaponStat(stat_name=WeaponStatType.critical_rate_perc, stat_data=14.0)],
-        [WeaponStat(stat_name=WeaponStatType.critical_rate_perc, stat_data=17.5)],
-        [WeaponStat(stat_name=WeaponStatType.critical_rate_perc, stat_data=21.0)],
-        [WeaponStat(stat_name=WeaponStatType.critical_rate_perc, stat_data=24.5)],
-        [WeaponStat(stat_name=WeaponStatType.critical_rate_perc, stat_data=28.0)],
-    ]
     file: str = "hbod"


### PR DESCRIPTION
Remove the conditional substat calculation of weapon `Harbinger of Dawn`
<img width="1617" height="1015" alt="Screenshot From 2026-02-20 21-05-28" src="https://github.com/user-attachments/assets/101dd764-7254-4513-88e4-adfe9b01ef11" />
<img width="1282" height="660" alt="Screenshot From 2026-02-20 21-05-24" src="https://github.com/user-attachments/assets/e5010816-d496-489b-b3fb-67d5d534ce86" />

Fixes: #498

## Summary by Sourcery

Bug Fixes:
- Eliminate erroneous conditional CRIT Rate substat scaling on Harbinger of Dawn refinements that led to incorrect stat calculations.