### PR TITLE
Stage the release v0.1.13 for Genshin Impact Luna IV (v6.3 Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ including but not limited to those outlined below.
     its intended functionality to work.
 
 With an extensive suite of 
-[**over 1420 diverse functionality tests**](https://github.com/gridhead/gi-loadouts/tree/main/test)
+[**over 1500 diverse functionality tests**](https://github.com/gridhead/gi-loadouts/tree/main/test)
 and
 [**impeccable 100% source code coverage**](https://github.com/gridhead/gi-loadouts/blob/main/.github/workflows/test.yml),
 we proudly invite auditors and analysts from 

--- a/gi_loadouts/__init__.py
+++ b/gi_loadouts/__init__.py
@@ -3,7 +3,7 @@ from importlib.metadata import metadata
 __metadict__ = metadata("gi-loadouts").json
 __versdata__ = __metadict__.get("version")
 
-__gicompat_vers__ = "6.2"
+__gicompat_vers__ = "6.3"
 __gicompat_part__ = "2"
 
 __donation__ = "https://github.com/sponsors/gridhead"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gi-loadouts"
-version = "0.1.13"
+version = "0.1.14"
 description = "Loadouts for Genshin Impact"
 authors = [
     {name = "Akashdeep Dhar", email = "akashdeep.dhar@gmail.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -150,7 +150,7 @@ wheels = [
 
 [[package]]
 name = "gi-loadouts"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
Stage the release v0.1.13 for Genshin Impact Luna IV (v6.3 Phase 2)

<img width="1617" height="1015" alt="Screenshot From 2026-02-21 16-25-46" src="https://github.com/user-attachments/assets/a471ce3f-33a6-478f-9e02-090bb67c74e1" />
<img width="622" height="860" alt="Screenshot From 2026-02-21 16-25-33" src="https://github.com/user-attachments/assets/6bfb3f38-8572-43d6-92c2-20c56996e024" />
<img width="622" height="690" alt="Screenshot From 2026-02-21 16-25-41" src="https://github.com/user-attachments/assets/d7437cf4-6e49-4f7c-a7cc-3d0ad42edcad" />

## Summary by Sourcery

Stage a new gi-loadouts release aligned with Genshin Impact 6.3 Phase 2 compatibility and updated test suite metrics.

Enhancements:
- Bump the gi-loadouts package version to 0.1.14 for the new release.
- Update the recorded Genshin Impact compatibility version to 6.3.

Documentation:
- Refresh README to reflect that the project now includes over 1500 functionality tests.