### PR TITLE
Stage the release v0.1.15 for Genshin Impact Luna V (v6.4 Phase 1)

### DIFF
--- a/gi_loadouts/__init__.py
+++ b/gi_loadouts/__init__.py
@@ -3,7 +3,7 @@ from importlib.metadata import metadata
 __metadict__ = metadata("gi-loadouts").json
 __versdata__ = __metadict__.get("version")
 
-__gicompat_vers__ = "6.3"
+__gicompat_vers__ = "6.4"
 __gicompat_part__ = "2"
 
 __donation__ = "https://github.com/sponsors/gridhead"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gi-loadouts"
-version = "0.1.14"
+version = "0.1.15"
 description = "Loadouts for Genshin Impact"
 authors = [
     {name = "Akashdeep Dhar", email = "akashdeep.dhar@gmail.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -151,7 +151,7 @@ wheels = [
 
 [[package]]
 name = "gi-loadouts"
-version = "0.1.14"
+version = "0.1.15"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
Stage the release v0.1.15 for Genshin Impact Luna V (v6.4 Phase 1)

<img width="622" height="860" alt="Screenshot From 2026-03-19 15-07-34" src="https://github.com/user-attachments/assets/50a68348-1759-4892-b41d-d4da41326867" />
<img width="622" height="690" alt="Screenshot From 2026-03-19 15-07-28" src="https://github.com/user-attachments/assets/7cbed539-d526-47ee-a91b-5cebe5a906c1" />
<img width="1617" height="1015" alt="Screenshot From 2026-03-19 15-07-16" src="https://github.com/user-attachments/assets/2ce43ef8-1e72-44f6-968c-049049dacc1f" />

## Summary by Sourcery

Prepare the project for the v0.1.15 release with updated Genshin Impact game compatibility metadata.

Enhancements:
- Update internal Genshin Impact compatibility markers to target version 6.4 Phase 1.

Build:
- Bump package version from 0.1.14 to 0.1.15 in project metadata.