### PR TITLE
Update GitHub workflows with Fedora Linux 43

### DIFF
--- a/.github/workflows/qlty.yml
+++ b/.github/workflows/qlty.yml
@@ -1,7 +1,7 @@
 ---
 name: Checking code quality
 
-on: [push, pull_request]
+on: push
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 ---
 name: Checking code functionality
 
-on: [push, pull_request]
+on: push
 
 jobs:
 
@@ -18,6 +18,8 @@ jobs:
             container: "fedora:40"
           - tox-env: "py313-dist"
             container: "fedora:42"
+          - tox-env: "py314-dist"
+            container: "fedora:43"
 
     container: ${{ matrix.container }}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.12.0
-envlist = py{312,313},py{312,313}-dist,cleaning
+envlist = py{312,313,314},py{312,313,314}-dist,cleaning
 isolated_build = true
 skip_missing_interpreters = true
 
@@ -18,26 +18,11 @@ commands_pre =
 commands =
     uv run --active pytest -o "addopts=--cov=gi_loadouts --cov-report term-missing --cov-report xml --cov-report html --cov-fail-under=100" test/ {posargs} -vvvv
 
-[testenv:py{312,313}-dist]
-setenv =
-    PYTHONPATH={toxinidir}
-    QT_QPA_PLATFORM=offscreen
-skip_install = true
-sitepackages = false
-deps = uv
-allowlist_externals =
-    uv
-commands_pre =
-    uv sync --active --extra dev
+[testenv:py{312,313,314}-dist]
 commands =
     uv run --active pytest -o "addopts=--numprocesses auto --cov=gi_loadouts --cov-report term-missing --cov-report xml --cov-report html --cov-fail-under=100" test/ {posargs} -vvvv
 
 [testenv:cleaning]
-deps = uv
-allowlist_externals =
-    uv
-commands_pre =
-    uv sync --active --extra dev
 commands =
     uv run --active ruff check --diff gi_loadouts/ test/
     uv run --active ruff format --check gi_loadouts/ test/


### PR DESCRIPTION
Update GitHub workflows with Fedora Linux 43

Fixes #522

## Summary by Sourcery

Expand supported Python and distribution test environments and update CI matrix accordingly.

Tests:
- Add Python 3.14 to tox environments for both regular and distribution test runs.
- Extend GitHub Actions test matrix to run distribution tests on Fedora 43 using the new Python 3.14 tox environment.