### PR TITLE
Change the default artifact to `None`

### DIFF
--- a/gi_loadouts/data/arti/__init__.py
+++ b/gi_loadouts/data/arti/__init__.py
@@ -62,6 +62,20 @@ from . import (
 )
 
 __artilist__ = {
+    none.team.__teamname__: ArtifactTeam(
+        name=none.team.__teamname__,
+        fwol=none.fwol(),
+        pmod=none.pmod(),
+        sdoe=none.sdoe(),
+        gboe=none.gboe(),
+        ccol=none.ccol(),
+        pairdata=none.team.__pairdata__,
+        pairtext=none.team.__pairtext__,
+        quaddata=none.team.__quaddata__,
+        quadtext=none.team.__quadtext__,
+        rare=[Rare.Star_0],
+        file=none.__name__.split(".")[-1],
+    ),
     dcrw.team.__teamname__: ArtifactTeam(
         name=dcrw.team.__teamname__,
         fwol=dcrw.fwol(),
@@ -831,20 +845,6 @@ __artilist__ = {
         quadtext=wdtp.team.__quadtext__,
         rare=[Rare.Star_4, Rare.Star_5],
         file=wdtp.__name__.split(".")[-1],
-    ),
-    none.team.__teamname__: ArtifactTeam(
-        name=none.team.__teamname__,
-        fwol=none.fwol(),
-        pmod=none.pmod(),
-        sdoe=none.sdoe(),
-        gboe=none.gboe(),
-        ccol=none.ccol(),
-        pairdata=none.team.__pairdata__,
-        pairtext=none.team.__pairtext__,
-        quaddata=none.team.__quaddata__,
-        quadtext=none.team.__quadtext__,
-        rare=[Rare.Star_0],
-        file=none.__name__.split(".")[-1],
     ),
 }
 

--- a/gi_loadouts/face/wind/main.py
+++ b/gi_loadouts/face/wind/main.py
@@ -48,7 +48,6 @@ class MainWindow(Rule):
                 self.arti_fwol_name_main,
                 self.arti_fwol_data_main,
                 "fwol",
-                self.arti_fwol_data_main,
                 self.arti_fwol_type_name,
                 self.arti_fwol_head_area,
                 self.arti_fwol_head_icon,
@@ -60,7 +59,6 @@ class MainWindow(Rule):
                 self.arti_pmod_name_main,
                 self.arti_pmod_data_main,
                 "pmod",
-                self.arti_pmod_data_main,
                 self.arti_pmod_type_name,
                 self.arti_pmod_head_area,
                 self.arti_pmod_head_icon,
@@ -72,7 +70,6 @@ class MainWindow(Rule):
                 self.arti_sdoe_name_main,
                 self.arti_sdoe_data_main,
                 "sdoe",
-                self.arti_sdoe_data_main,
                 self.arti_sdoe_type_name,
                 self.arti_sdoe_head_area,
                 self.arti_sdoe_head_icon,
@@ -84,7 +81,6 @@ class MainWindow(Rule):
                 self.arti_gboe_name_main,
                 self.arti_gboe_data_main,
                 "gboe",
-                self.arti_gboe_data_main,
                 self.arti_gboe_type_name,
                 self.arti_gboe_head_area,
                 self.arti_gboe_head_icon,
@@ -96,21 +92,20 @@ class MainWindow(Rule):
                 self.arti_ccol_name_main,
                 self.arti_ccol_data_main,
                 "ccol",
-                self.arti_ccol_data_main,
                 self.arti_ccol_type_name,
                 self.arti_ccol_head_area,
                 self.arti_ccol_head_icon,
             ),
         ]:
             self.change_rarity_backdrop_by_changing_type(
-                item[1], item[2], item[6], item[9], item[5]
+                item[1], item[2], item[6], item[8], item[5]
             )
             self.change_artifact_team_by_changing_type(item[1], item[5])
             self.change_data_by_changing_level_or_stat(
                 item[0], item[1], item[2], item[3], item[4], item[5]
             )
             self.change_artifact_substats_by_changing_rarity_or_mainstat(item[2], item[3], item[5])
-            self.change_levels_backdrop_by_changing_rarity(item[0], item[8], item[2])
+            self.change_levels_backdrop_by_changing_rarity(item[0], item[7], item[2])
         self.regulate_taborder()
         self.statarea.showMessage("Ready.")
 

--- a/test/face/otpt/test_otpt.py
+++ b/test/face/otpt/test_otpt.py
@@ -6,6 +6,7 @@ from PySide6.QtWidgets import QMainWindow, QMessageBox
 from pytestqt.qtbot import QtBot
 
 from gi_loadouts import __versdata__
+from gi_loadouts.data.arti import __artilist__
 from gi_loadouts.data.char import __charmaps__
 from gi_loadouts.data.weap import Family
 from gi_loadouts.face.wind.main import MainWindow
@@ -359,7 +360,7 @@ def test_otpt(runner: MainWindow, qtbot: QtBot, type: str, cond: str) -> None:
 )
 def test_otpt_fail(runner: MainWindow, qtbot: QtBot, subdata: str) -> None:
     """
-    Test failing to generate final calculation based on character, weapon and default artifact
+    Test failing to generate the final calculation based on character, weapon and default artifact
 
     :return:
     """
@@ -367,6 +368,9 @@ def test_otpt_fail(runner: MainWindow, qtbot: QtBot, subdata: str) -> None:
     """
     Set the user interface elements as intended
     """
+    name = choice([item for item in __artilist__ if item != "None"])
+    for area in ["fwol", "pmod", "sdoe", "gboe", "ccol"]:
+        getattr(runner, f"arti_{area}_type").setCurrentText(name)
     if subdata == "invalid":
         runner.arti_fwol_data_a.setText("abc")
 

--- a/test/face/wind/arti/test_arti_file.py
+++ b/test/face/wind/arti/test_arti_file.py
@@ -104,7 +104,7 @@ def test_arti_save_name(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture,
     """
     Set the user interface elements as intended
     """
-    name = choice([item for item in __artilist__.keys() if item != "None"])
+    name = choice([item for item in __artilist__ if item != "None"])
     getattr(runner, f"arti_{area}_type").setCurrentText(name)
     conf["rare"] = choice([item for item in __artilist__[name].rare])
     getattr(runner, f"arti_{area}_rare").setCurrentText(conf["rare"].value.name)
@@ -155,6 +155,12 @@ def test_arti_save_fail(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture,
 
     :return:
     """
+
+    """
+    Set the user interface elements as intended
+    """
+    name = choice([item for item in __artilist__ if item != "None"])
+    getattr(runner, f"arti_{area}_type").setCurrentText(name)
 
     """
     Perform the action of saving the artifact information
@@ -350,9 +356,9 @@ def test_arti_load_nope(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture,
     """
     Confirm if the user interface elements change accordingly
     """
-    assert getattr(runner, f"arti_{area}_type").currentText() == "A Day Carved From Rising Winds"
-    assert getattr(runner, f"arti_{area}_rare").currentText() == "Star 4"
-    assert getattr(runner, f"arti_{area}_levl").currentText() == "Level 00"
+    assert getattr(runner, f"arti_{area}_type").currentText() == "None"
+    assert getattr(runner, f"arti_{area}_rare").currentText() == "Star 0"
+    assert getattr(runner, f"arti_{area}_levl").currentText() == "None"
 
 
 @pytest.mark.parametrize(
@@ -843,7 +849,7 @@ def test_arti_save_yaml_actual(
     """
     Set the user interface elements as intended
     """
-    name = choice([item for item in __artilist__.keys() if item != "None"])
+    name = choice([item for item in __artilist__ if item != "None"])
     getattr(runner, f"arti_{area}_type").setCurrentText(name)
     conf["rare"] = choice([item for item in __artilist__[name].rare])
     getattr(runner, f"arti_{area}_rare").setCurrentText(conf["rare"].value.name)
@@ -928,7 +934,7 @@ def test_arti_save_json_actual(
     """
     Set the user interface elements as intended
     """
-    name = choice([item for item in __artilist__.keys() if item != "None"])
+    name = choice([item for item in __artilist__ if item != "None"])
     getattr(runner, f"arti_{area}_type").setCurrentText(name)
     conf["rare"] = choice([item for item in __artilist__[name].rare])
     getattr(runner, f"arti_{area}_rare").setCurrentText(conf["rare"].value.name)
@@ -1134,7 +1140,7 @@ def test_arti_save_nope(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture,
     """
     Set the user interface elements as intended
     """
-    name = choice([item for item in __artilist__.keys() if item != "None"])
+    name = choice([item for item in __artilist__ if item != "None"])
     getattr(runner, f"arti_{area}_type").setCurrentText(name)
     conf["rare"] = choice([item for item in __artilist__[name].rare])
     getattr(runner, f"arti_{area}_rare").setCurrentText(conf["rare"].value.name)

--- a/test/face/wind/team/test_team_file.py
+++ b/test/face/wind/team/test_team_file.py
@@ -88,6 +88,12 @@ def test_team_save_fail(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture,
     """
 
     """
+    Set the user interface elements as intended
+    """
+    for area in ["fwol", "pmod", "sdoe", "gboe", "ccol"]:
+        getattr(runner, f"arti_{area}_type").setCurrentText(actual[area]["type"])
+
+    """
     Perform the action of saving the artifact collection information
     """
     mocker.patch.object(file.FileHandling, "save", return_value=True)
@@ -194,11 +200,9 @@ def test_team_load_nope(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture,
     Confirm if the user interface elements change accordingly
     """
     for area in actual.keys():
-        assert (
-            getattr(runner, f"arti_{area}_type").currentText() == "A Day Carved From Rising Winds"
-        )
-        assert getattr(runner, f"arti_{area}_rare").currentText() == "Star 4"
-        assert getattr(runner, f"arti_{area}_levl").currentText() == "Level 00"
+        assert getattr(runner, f"arti_{area}_type").currentText() == "None"
+        assert getattr(runner, f"arti_{area}_rare").currentText() == "Star 0"
+        assert getattr(runner, f"arti_{area}_levl").currentText() == "None"
 
 
 @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ skip_missing_interpreters = true
 [testenv]
 setenv =
     PYTHONPATH={toxinidir}
+    QT_QPA_PLATFORM=offscreen
 skip_install = true
 sitepackages = false
 deps = uv
@@ -20,6 +21,7 @@ commands =
 [testenv:py{312,313}-dist]
 setenv =
     PYTHONPATH={toxinidir}
+    QT_QPA_PLATFORM=offscreen
 skip_install = true
 sitepackages = false
 deps = uv


### PR DESCRIPTION
Change the default artifact to `None`

Fixes #499

## Summary by Sourcery

Set the placeholder "None" artifact as the default selection and align UI behavior, tests, and CI configuration with that behavior.

Bug Fixes:
- Ensure wiping artifacts or teams correctly triggers UI updates even when the artifact type is already set to "None".

Enhancements:
- Promote the "None" artifact entry in the artifact registry so it becomes the default artifact.
- Simplify test artifact selection by iterating directly over the artifact registry keys instead of using .keys().

Build:
- Configure tox environments to run Qt-based tests in offscreen mode via QT_QPA_PLATFORM=offscreen.

Tests:
- Update artifact, team, and output tests to expect the "None" artifact with Star 0 rarity and to explicitly set artifact types before save/fail scenarios.