### PR TITLE
Stage the release v0.1.16 for Genshin Impact Luna VI (v6.5 Phase 2)

### DIFF
--- a/gi_loadouts/__init__.py
+++ b/gi_loadouts/__init__.py
@@ -3,7 +3,7 @@ from importlib.metadata import metadata
 __metadict__ = metadata("gi-loadouts").json
 __versdata__ = __metadict__.get("version")
 
-__gicompat_vers__ = "6.4"
+__gicompat_vers__ = "6.5"
 __gicompat_part__ = "2"
 
 __donation__ = "https://github.com/sponsors/gridhead"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gi-loadouts"
-version = "0.1.15"
+version = "0.1.16"
 description = "Loadouts for Genshin Impact"
 authors = [
     {name = "Akashdeep Dhar", email = "akashdeep.dhar@gmail.com"},


### PR DESCRIPTION
Stage the release v0.1.16 for Genshin Impact Luna VI (v6.5 Phase 2)

<img width="622" height="690" alt="image" src="https://github.com/user-attachments/assets/eb64f763-6648-4a38-8dd5-fc890b468c10" />

<img width="622" height="860" alt="image" src="https://github.com/user-attachments/assets/93b17a3f-e0f5-479e-9846-cd2525cb7f1d" />

## Summary by Sourcery

Stage gi-loadouts release v0.1.16 with updated Genshin Impact compatibility metadata.

Enhancements:
- Update recorded Genshin Impact compatibility version to 6.5 Phase 2.

Build:
- Bump package version to 0.1.16 in project metadata.