### PR TITLE
Create separate GitHub Action for generating point releases

### DIFF
--- a/.github/workflows/gnul.yml
+++ b/.github/workflows/gnul.yml
@@ -1,9 +1,14 @@
 ---
-name: Compiling the nightly project executable binary for GNU/Linux OSes
+name: Compiling the unique project executable binary for GNU/Linux OSes
 
 on:
   schedule:
     - cron: 0 0 * * *
+  workflow_call:
+    inputs:
+      identifier:
+        required: true
+        type: string
 
 jobs:
 
@@ -25,12 +30,18 @@ jobs:
           python-version: 3.13 || 3.14
 
       - name: Evaluate the revision identifier for versioning
-        id: hash
+        id: identifier
         shell: bash
-        run: echo "code=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_OUTPUT
+        run: |
+             if [ "${{ github.event_name }}" = "schedule" ]; then
+               echo "code=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_OUTPUT
+             else
+               echo "code=${{ inputs.identifier }}" >> $GITHUB_OUTPUT
+             fi
 
       - name: Update the interstitial identifier for versioning
-        run: sed --in-place "s/^version = \"\(.*\)\"/version = \"\1+${{ steps.hash.outputs.code }}\"/" pyproject.toml
+        if: github.event_name == 'schedule'
+        run: sed --in-place "s/^version = \"\(.*\)\"/version = \"\1+${{ steps.identifier.outputs.code }}\"/" pyproject.toml
 
       - name: Install the project's required runtime dependencies
         run: pip install .
@@ -42,7 +53,7 @@ jobs:
           mode: onefile
           enable-plugins: pyside6
           output-dir: dist
-          output-file: gi-loadouts-${{ steps.hash.outputs.code }}
+          output-file: gi-loadouts-${{ steps.identifier.outputs.code }}
           linux-icon: assets/icon/icon.ico
 
       - name: Upload the compiled binaries to the GitHub Artifacts

--- a/.github/workflows/mswn.yml
+++ b/.github/workflows/mswn.yml
@@ -1,9 +1,14 @@
 ---
-name: Compiling the nightly project executable binary for Microsoft Windows
+name: Compiling the unique project executable binary for Microsoft Windows
 
 on:
   schedule:
     - cron: 0 0 * * *
+  workflow_call:
+    inputs:
+      identifier:
+        required: true
+        type: string
 
 jobs:
 
@@ -25,12 +30,18 @@ jobs:
           python-version: 3.13 || 3.14
 
       - name: Evaluate the revision identifier for versioning
-        id: hash
+        id: identifier
         shell: bash
-        run: echo "code=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_OUTPUT
+        run: |
+             if [ "${{ github.event_name }}" = "schedule" ]; then
+               echo "code=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_OUTPUT
+             else
+               echo "code=${{ inputs.identifier }}" >> $GITHUB_OUTPUT
+             fi
 
       - name: Update the interstitial identifier for versioning
-        run: (Get-Content -Raw pyproject.toml) -replace 'version\s*=\s*"([^"]*)"', ('version = "$1+${{ steps.hash.outputs.code }}"') | Set-Content pyproject.toml
+        if: github.event_name == 'schedule'
+        run: (Get-Content -Raw pyproject.toml) -replace 'version\s*=\s*"([^"]*)"', ('version = "$1+${{ steps.identifier.outputs.code }}"') | Set-Content pyproject.toml
 
       - name: Install the project's required runtime dependencies
         run: pip install .
@@ -42,7 +53,7 @@ jobs:
           mode: onefile
           enable-plugins: pyside6
           output-dir: dist
-          output-file: gi-loadouts-${{ steps.hash.outputs.code }}.exe
+          output-file: gi-loadouts-${{ steps.identifier.outputs.code }}.exe
           windows-console-mode: disable
           windows-icon-from-ico: assets/icon/icon.ico
 

--- a/.github/workflows/rlse.yml
+++ b/.github/workflows/rlse.yml
@@ -1,0 +1,100 @@
+---
+name: Creating the point release
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+jobs:
+
+  ci-make-gnul:
+    uses: ./.github/workflows/gnul.yml
+    with:
+      identifier: ${{ github.ref_name }}
+
+  ci-make-mswn:
+    uses: ./.github/workflows/mswn.yml
+    with:
+      identifier: ${{ github.ref_name }}
+
+  ci-make-pypi:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+
+      - name: Checkout the codebase in a local working directory
+        uses: actions/checkout@v7
+
+      - name: Establish a functioning Python development environment
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.13 || 3.14
+
+      - name: Install the build dependencies
+        run: pip install build
+
+      - name: Build the source distribution and wheel
+        run: python -m build
+
+      - name: Upload the distribution packages to the GitHub Artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: gi-loadouts.pypi
+          path: dist/*
+          compression-level: 9
+          overwrite: true
+
+  ci-rlse:
+
+    needs: [ci-make-gnul, ci-make-mswn, ci-make-pypi]
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    strategy:
+      fail-fast: false
+
+    steps:
+
+      - name: Download the GNU/Linux executable binary
+        uses: actions/download-artifact@v7
+        with:
+          name: gi-loadouts.gnul
+          path: dist/gnul
+
+      - name: Download the Microsoft Windows executable binary
+        uses: actions/download-artifact@v7
+        with:
+          name: gi-loadouts.mswn
+          path: dist/mswn
+
+      - name: Download the Python distribution packages
+        uses: actions/download-artifact@v7
+        with:
+          name: gi-loadouts.pypi
+          path: dist/pypi
+
+      - name: Create the draft release on GitHub
+        run: |
+             gh release create ${{ github.ref_name }} \
+               dist/gnul/* \
+               dist/mswn/* \
+               --repo ${{ github.repository }} \
+               --title "${{ github.ref_name }}" \
+               --draft \
+               --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish the distribution packages to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/pypi


### PR DESCRIPTION
Create separate GitHub Action for generating point releases

Fixes #546

## Summary by Sourcery

Introduce a dedicated release workflow that reuses the existing platform build jobs and automates tagged point releases.

Build:
- Allow the GNU/Linux and Windows build workflows to be triggered via workflow_call with an explicit build identifier instead of only scheduled runs.
- Adjust artifact naming, version suffixing, and overwrite behavior in build workflows to support both nightly and release builds.
- Add a new release workflow that, on semantic-version tags, builds binaries and Python packages, creates a draft GitHub release with attached artifacts, and publishes packages to PyPI.