### PR TITLE
Complete the 4-piece bonus for `Disenchantment in Deep Shadow`

### DIFF
--- a/gi_loadouts/data/arti/dids.py
+++ b/gi_loadouts/data/arti/dids.py
@@ -9,7 +9,7 @@ class team(BaseModel):
     __pairdata__ = [ATTR(stat_name=STAT.attack_perc, stat_data=18)]
     __pairtext__ = "ATK +18%."
     __quaddata__ = []
-    __quadtext__ = "Increases Superconduct Reaction DMG by 80%. When the wielder attacks opponents affected by Superconduct, this attack's CRIT Rate is increased by 16%. An all-new blessing may be obtained as you make your way toward Snezhnaya..."
+    __quadtext__ = "Increases Superconduct Reaction DMG by 80% and Stellar-Conduct Reaction DMG by 40%. When the wielder attacks opponents affected by Superconduct or Stellar-Conduct, this attack's CRIT Rate is increased by 16%."
 
 
 class fwol(team, FWOL):


### PR DESCRIPTION
The 7.0 release fills in the placeholder the 4-piece bonus ended on. The "...toward Snezhnaya" teaser now resolves into the Stellar-Conduct half: Stellar-Conduct Reaction DMG +40%, and the CRIT Rate buff also triggers off Stellar-Conduct.

Updated text to match the finalized in-game string. closes #572

## Summary by Sourcery

Enhancements:
- Extend the 4-piece set bonus to include Stellar-Conduct Reaction DMG and CRIT Rate interactions alongside Superconduct.