### PR TITLE
Disable caching while building executable binaries

### DIFF
--- a/.github/workflows/gnul.yml
+++ b/.github/workflows/gnul.yml
@@ -55,6 +55,7 @@ jobs:
           output-dir: dist
           output-file: gi-loadouts-${{ steps.identifier.outputs.code }}
           linux-icon: assets/icon/icon.ico
+          disable-cache: true
 
       - name: Upload the compiled binaries to the GitHub Artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/mswn.yml
+++ b/.github/workflows/mswn.yml
@@ -56,6 +56,7 @@ jobs:
           output-file: gi-loadouts-${{ steps.identifier.outputs.code }}.exe
           windows-console-mode: disable
           windows-icon-from-ico: assets/icon/icon.ico
+          disable-cache: true
 
       - name: Upload the compiled binaries to the GitHub Artifacts
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Disable caching while building executable binaries

## Summary by Sourcery

CI:
- Disable cache usage for executable binary build steps in GitHub Actions workflows.