### PR TITLE
Stage the release v0.1.18 for Genshin Impact Luna VIII (v6.7 Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ including but not limited to those outlined below.
     its intended functionality to work.
 
 With an extensive suite of 
-[**over 1558 diverse functionality tests**](https://github.com/gridhead/gi-loadouts/tree/main/test)
+[**over 1584 diverse functionality tests**](https://github.com/gridhead/gi-loadouts/tree/main/test)
 and
 [**impeccable 100% source code coverage**](https://github.com/gridhead/gi-loadouts/blob/main/.github/workflows/test.yml),
 we proudly invite auditors and analysts from 

--- a/gi_loadouts/__init__.py
+++ b/gi_loadouts/__init__.py
@@ -3,7 +3,7 @@ from importlib.metadata import metadata
 __metadict__ = metadata("gi-loadouts").json
 __versdata__ = __metadict__.get("version")
 
-__gicompat_vers__ = "6.6"
+__gicompat_vers__ = "6.7"
 __gicompat_part__ = "2"
 
 __donation__ = "https://github.com/sponsors/gridhead"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gi-loadouts"
-version = "0.1.17"
+version = "0.1.18"
 description = "Loadouts for Genshin Impact"
 authors = [
     {name = "Akashdeep Dhar", email = "akashdeep.dhar@gmail.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -127,7 +127,7 @@ wheels = [
 
 [[package]]
 name = "gi-loadouts"
-version = "0.1.17"
+version = "0.1.18"
 source = { editable = "." }
 dependencies = [
     { name = "pillow" },


### PR DESCRIPTION
Stage the release v0.1.18 for Genshin Impact Luna VIII (v6.7 Phase 2)

<img width="622" height="860" alt="image" src="https://github.com/user-attachments/assets/77928692-1902-4898-ba08-543388d88088" />

<img width="622" height="690" alt="image" src="https://github.com/user-attachments/assets/3edbacd1-cc48-417a-a192-3f17c538ab53" />

<img width="1617" height="1015" alt="image" src="https://github.com/user-attachments/assets/8b56dd61-58eb-41bb-b20c-8a42f9582b8a" />

## Summary by Sourcery

Stage release v0.1.18 of gi-loadouts with updated game compatibility and project metadata.

Enhancements:
- Update internal Genshin Impact client compatibility marker to version 6.7 Phase 2.

Build:
- Bump project version to 0.1.18 and regenerate the uv.lock file for the new release.

Documentation:
- Refresh README to reflect expanded test suite count.