### PR TITLE
Sign the release artifacts with Sigstore

### DIFF
--- a/.github/workflows/rlse.yml
+++ b/.github/workflows/rlse.yml
@@ -82,11 +82,21 @@ jobs:
           name: gi-loadouts.pypi
           path: dist/pypi
 
+      - name: Sign the release artifacts with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3
+        with:
+          inputs: >-
+            ./dist/gnul/*
+            ./dist/mswn/*
+            ./dist/pypi/*.tar.gz
+            ./dist/pypi/*.whl
+
       - name: Create the draft release on GitHub
         run: |
              gh release create ${{ github.ref_name }} \
                dist/gnul/* \
                dist/mswn/* \
+               dist/pypi/* \
                --repo ${{ github.repository }} \
                --title "${{ github.ref_name }}" \
                --draft \


### PR DESCRIPTION
Sign the release artifacts with Sigstore

## Summary by Sourcery

Sign release artifacts in the GitHub workflow and include PyPI distributions in the drafted GitHub release.

CI:
- Add Sigstore signing step to the release workflow for all generated artifacts.
- Update the release creation step to attach PyPI distribution files to the GitHub draft release.