### PR TITLE
Parallelize Nuitka builds and resolve Sigstore action version

### DIFF
--- a/.github/workflows/gnul.yml
+++ b/.github/workflows/gnul.yml
@@ -56,6 +56,7 @@ jobs:
           output-file: gi-loadouts-${{ steps.identifier.outputs.code }}
           linux-icon: assets/icon/icon.ico
           disable-cache: true
+          extra-arguments: --jobs=4
 
       - name: Upload the compiled binaries to the GitHub Artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/mswn.yml
+++ b/.github/workflows/mswn.yml
@@ -57,6 +57,7 @@ jobs:
           windows-console-mode: disable
           windows-icon-from-ico: assets/icon/icon.ico
           disable-cache: true
+          extra-arguments: --jobs=4
 
       - name: Upload the compiled binaries to the GitHub Artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/rlse.yml
+++ b/.github/workflows/rlse.yml
@@ -83,7 +83,7 @@ jobs:
           path: dist/pypi
 
       - name: Sign the release artifacts with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3
+        uses: sigstore/gh-action-sigstore-python@v3.4.0
         with:
           inputs: >-
             ./dist/gnul/*


### PR DESCRIPTION
Parallelize Nuitka builds and resolve Sigstore action version

## Summary by Sourcery

Parallelize Nuitka build jobs in CI and pin the Sigstore signing action to a specific version for release workflows.

CI:
- Run Nuitka builds with multiple jobs in GNU/Linux and Windows GitHub workflows to speed up compilation.
- Pin the Sigstore Python GitHub Action to version v3.4.0 in the release workflow to avoid ambiguity in action resolution.