### PR TITLE
Replace `extra-arguments` with `jobs` for parallelization

### DIFF
--- a/.github/workflows/gnul.yml
+++ b/.github/workflows/gnul.yml
@@ -56,7 +56,7 @@ jobs:
           output-file: gi-loadouts-${{ steps.identifier.outputs.code }}
           linux-icon: assets/icon/icon.ico
           disable-cache: true
-          extra-arguments: --jobs=4
+          jobs: 4
 
       - name: Upload the compiled binaries to the GitHub Artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/mswn.yml
+++ b/.github/workflows/mswn.yml
@@ -57,7 +57,7 @@ jobs:
           windows-console-mode: disable
           windows-icon-from-ico: assets/icon/icon.ico
           disable-cache: true
-          extra-arguments: --jobs=4
+          jobs: 4
 
       - name: Upload the compiled binaries to the GitHub Artifacts
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Replace `extra-arguments` with `jobs` for parallelization

## Summary by Sourcery

Update GitHub workflows to use the dedicated jobs parameter for build parallelization.

Build:
- Switch GitHub workflow build steps from extra-arguments to the jobs parameter to configure parallel compilation.

CI:
- Align CI workflows with the new jobs-based parallelization configuration for build actions.