### PR TITLE
Remove stability days check from the Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,6 @@
   },
   "automergeStrategy": "rebase",
   "rangeStrategy": "widen",
-  "stabilityDays": 4,
   "labels": ["dependencies"],
   "packageRules": [
     {


### PR DESCRIPTION
Remove stability days requirement from Renovate configuration

## Summary by Sourcery

Build:
- Relax Renovate dependency update rules by removing the stability days constraint from renovate.json.