### PR TITLE
Publish to PyPI before Sigstore signing

### DIFF
--- a/.github/workflows/gnul.yml
+++ b/.github/workflows/gnul.yml
@@ -56,7 +56,6 @@ jobs:
           output-file: gi-loadouts-${{ steps.identifier.outputs.code }}
           linux-icon: assets/icon/icon.ico
           disable-cache: true
-          jobs: 4
 
       - name: Upload the compiled binaries to the GitHub Artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/mswn.yml
+++ b/.github/workflows/mswn.yml
@@ -57,7 +57,6 @@ jobs:
           windows-console-mode: disable
           windows-icon-from-ico: assets/icon/icon.ico
           disable-cache: true
-          jobs: 4
 
       - name: Upload the compiled binaries to the GitHub Artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/rlse.yml
+++ b/.github/workflows/rlse.yml
@@ -82,6 +82,11 @@ jobs:
           name: gi-loadouts.pypi
           path: dist/pypi
 
+      - name: Publish the distribution packages to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/pypi
+
       - name: Sign the release artifacts with Sigstore
         uses: sigstore/gh-action-sigstore-python@v3.4.0
         with:
@@ -103,8 +108,3 @@ jobs:
                --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish the distribution packages to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/pypi


### PR DESCRIPTION
Publish to PyPI before Sigstore signing

## Summary by Sourcery

Adjust release workflows to publish Python packages to PyPI before Sigstore signing and simplify binary build configurations.

Build:
- Move PyPI publication step before Sigstore signing in the release workflow.
- Remove explicit parallel jobs configuration from GNU/Linux and Windows build workflows.