### PR TITLE
Center the children dialog on the parent window

### DIFF
--- a/assets/otpt.ui
+++ b/assets/otpt.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>otptwind</class>
- <widget class="QMainWindow" name="otptwind">
+ <widget class="QDialog" name="otptwind">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -35,6 +35,14 @@
    <string notr="true">font: 10pt &quot;IBM Plex Sans&quot;;</string>
   </property>
   <widget class="QWidget" name="centwdgt">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>1260</width>
+     <height>600</height>
+    </rect>
+   </property>
    <widget class="QFrame" name="head_area">
     <property name="geometry">
      <rect>

--- a/gi_loadouts/face/info/main.py
+++ b/gi_loadouts/face/info/main.py
@@ -9,8 +9,8 @@ from .info import Ui_info
 
 
 class InfoDialog(QDialog, Ui_info):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent=parent)
         self.setupUi(self)
         self.setWindowTitle(f"Loadouts for Genshin Impact v{__versdata__}")
         self.icon.setPixmap(QPixmap(f":pmon/imgs/pmon/{int(time() % 10)}.webp"))

--- a/gi_loadouts/face/lcns/main.py
+++ b/gi_loadouts/face/lcns/main.py
@@ -8,8 +8,8 @@ from .lcns import Ui_lcns
 
 
 class LcnsDialog(QDialog, Ui_lcns):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent=parent)
         self.setupUi(self)
         self.setWindowTitle(f"Loadouts for Genshin Impact v{__versdata__}")
         self.icon.setPixmap(QPixmap(f":pmon/imgs/pmon/{int(time() % 10)}.webp"))

--- a/gi_loadouts/face/otpt/main.py
+++ b/gi_loadouts/face/otpt/main.py
@@ -1,13 +1,11 @@
-from PySide6.QtCore import Qt
-
 from ... import __versdata__
 from ...type.calc import CHAR
 from .rule import Rule
 
 
 class OtptWindow(Rule):
-    def __init__(self, char: dict, weap: dict, arti: dict, tyvt: CHAR) -> None:
-        super().__init__()
+    def __init__(self, char: dict, weap: dict, arti: dict, tyvt: CHAR, parent=None) -> None:
+        super().__init__(parent=parent)
         self.arti = arti
         self.char = char
         self.weap = weap
@@ -16,7 +14,6 @@ class OtptWindow(Rule):
         self.setWindowTitle(
             f"Loadouts for Genshin Impact v{__versdata__} - {self.char['char'].name.value}"
         )
-        self.setWindowModality(Qt.ApplicationModal)
         self.manage_assets()
         self.populate_header()
         self.populate_blanks()

--- a/gi_loadouts/face/otpt/otpt.py
+++ b/gi_loadouts/face/otpt/otpt.py
@@ -1,7 +1,7 @@
 ################################################################################
 ## Form generated from reading UI file 'otpt.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.8.1
+## Created by: Qt User Interface Compiler version 6.11.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -26,6 +26,7 @@ class Ui_otptwind:
         otptwind.setStyleSheet('font: 10pt "IBM Plex Sans";')
         self.centwdgt = QWidget(otptwind)
         self.centwdgt.setObjectName("centwdgt")
+        self.centwdgt.setGeometry(QRect(0, 0, 1260, 600))
         self.head_area = QFrame(self.centwdgt)
         self.head_area.setObjectName("head_area")
         self.head_area.setGeometry(QRect(200, 5, 1055, 75))
@@ -1932,7 +1933,6 @@ class Ui_otptwind:
             'font: 87 10pt "Font Awesome 6 Free Solid"; color: rgba(255, 255, 255, 255);'
         )
         self.area_crvl_icon.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        otptwind.setCentralWidget(self.centwdgt)
         self.char_back.raise_()
         self.head_area.raise_()
         self.char_area.raise_()

--- a/gi_loadouts/face/otpt/rule.py
+++ b/gi_loadouts/face/otpt/rule.py
@@ -1,13 +1,13 @@
 from PySide6.QtGui import QPixmap
-from PySide6.QtWidgets import QMainWindow
+from PySide6.QtWidgets import QDialog
 
 from ...face.util import modify_graphics_resource
 from .otpt import Ui_otptwind
 
 
-class Rule(QMainWindow, Ui_otptwind):
-    def __init__(self) -> None:
-        super().__init__()
+class Rule(QDialog, Ui_otptwind):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
         self.arti = None
         self.char = None
         self.weap = None

--- a/gi_loadouts/face/scan/main.py
+++ b/gi_loadouts/face/scan/main.py
@@ -5,8 +5,9 @@ from .rule import Rule
 
 
 class ScanDialog(Rule):
-    def __init__(self, part: str = "") -> None:
+    def __init__(self, part: str = "", parent=None) -> None:
         super().__init__()
+        self.setParent(parent, self.windowFlags())
         self.part = part
         self.setupUi(self)
         self.setWindowTitle(f"Loadouts for Genshin Impact v{__versdata__}")

--- a/gi_loadouts/face/wind/rule.py
+++ b/gi_loadouts/face/wind/rule.py
@@ -592,8 +592,9 @@ class Rule(QMainWindow, Ui_mainwind, Facility, Assess):
                     "pair": self.collection.pair,
                 },
                 self.c_tyvt,
+                parent=self,
             )
-            self.otptobjc.show()
+            self.otptobjc.exec()
         except Exception as expt:
             self.show_dialog(
                 QMessageBox.Information,
@@ -653,8 +654,8 @@ class Rule(QMainWindow, Ui_mainwind, Facility, Assess):
 
         :return:
         """
-        self.infoobjc = InfoDialog()
-        self.infoobjc.show()
+        self.infoobjc = InfoDialog(parent=self)
+        self.infoobjc.exec()
 
     def show_lcns_dialog(self) -> None:
         """
@@ -662,8 +663,8 @@ class Rule(QMainWindow, Ui_mainwind, Facility, Assess):
 
         :return:
         """
-        self.lcnsobjc = LcnsDialog()
-        self.lcnsobjc.show()
+        self.lcnsobjc = LcnsDialog(parent=self)
+        self.lcnsobjc.exec()
 
     def show_scan_dialog(self, part: str) -> None:
         """
@@ -671,7 +672,7 @@ class Rule(QMainWindow, Ui_mainwind, Facility, Assess):
 
         :return:
         """
-        self.scanobjc = ScanDialog(part)
+        self.scanobjc = ScanDialog(part, parent=self)
         if self.scanobjc.exec() == QDialog.Accepted:
             info = self.scanobjc.keep_info()
 


### PR DESCRIPTION
Center the children dialog on the parent window

Fixes #631

## Summary by Sourcery

Center and modalize child dialogs relative to their parent window in the UI.

Bug Fixes:
- Ensure info, license, scan, and output dialogs open as modal child dialogs centered on their parent instead of independent windows.

Enhancements:
- Refactor the output window from a main window to a dialog and wire parent propagation through dialog constructors.
- Update Qt UI and dialog setup to align with QDialog usage and remove manual application modality settings.