### PR TITLE
Optimize test cases to consume less memory

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,29 +1,31 @@
+from collections.abc import Generator
+
 import pytest
-from pytestqt.qtbot import QtBot
+from PySide6.QtWidgets import QApplication
 
 from gi_loadouts.face.scan.main import ScanDialog
 from gi_loadouts.face.wind.main import MainWindow
 
 
-@pytest.fixture
-def runner(qtbot: QtBot) -> MainWindow:
+@pytest.fixture(scope="session")
+def runner(qapp: QApplication) -> Generator[MainWindow, None, None]:
     """
     Fixture for MainWindow class
 
     :return: Instance of MainWindow
     """
     testwind = MainWindow()
-    qtbot.addWidget(testwind)
-    return testwind
+    yield testwind
+    testwind.close()
 
 
-@pytest.fixture
-def scantest(qtbot: QtBot) -> ScanDialog:
+@pytest.fixture(scope="session")
+def scantest(qapp: QApplication) -> Generator[ScanDialog, None, None]:
     """
     Fixture for ScanDialog class
 
     :return: Instance of ScanDialog
     """
     testscan = ScanDialog("fwol")
-    qtbot.addWidget(testscan)
-    return testscan
+    yield testscan
+    testscan.close()

--- a/test/face/otpt/test_otpt.py
+++ b/test/face/otpt/test_otpt.py
@@ -161,8 +161,10 @@ def test_otpt(runner: MainWindow, qtbot: QtBot, type: str, cond: str) -> None:
     Setting the character statistics
     """
     c_name = choice([name for name, data in __charmaps__.items() if data().weapon.value == type])
+    c_elem = __charmaps__[c_name]().vision.value.name
     c_levl = choice(list(item.value.name for item in Level))
     c_cons = choice(list(item.value.name for item in Cons))
+    runner.head_char_elem.setCurrentText(c_elem.title())
     runner.head_char_name.setCurrentText(c_name)
     runner.head_char_levl.setCurrentText(c_levl)
     runner.head_char_cons.setCurrentText(c_cons)

--- a/test/face/scan/test_scan.py
+++ b/test/face/scan/test_scan.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 import pytest
 from PIL.ImageQt import QImage
-from PySide6.QtCore import QMimeData, Qt
+from PySide6.QtCore import QMimeData, Qt, QThread
 from PySide6.QtWidgets import QApplication, QDialog, QFileDialog, QMessageBox
 from pytesseract import TesseractError
 from pytest_mock import MockerFixture
@@ -606,6 +606,11 @@ def test_scan_import_arti(
     """
 
     """
+    Set the user interface elements to a known state
+    """
+    qtbot.mouseClick(scantest.arti_back_wipe, Qt.LeftButton)
+
+    """
     Create the Tesseract training data
     """
     mocker.patch("gi_loadouts.conf.data_prefix", f"{uuid4().hex.upper()[0:8]}-")
@@ -975,3 +980,54 @@ def test_wind_import_arti(
         assert getattr(runner, f"arti_{__dist__[dist]['part']}_data_{sbst}").text() == str(
             __rtrn__[dist]["stat"]["seco"][f"{sbst}"].stat_data
         )
+
+
+@pytest.mark.parametrize("_", [pytest.param(None, id="face.scan: Manually invoke __del__")])
+def test_scan_delete_pass(scantest: ScanDialog, mocker: MockerFixture, _: None) -> None:
+    """
+    Test manually invoking __del__ on ScanDialog
+
+    :return:
+    """
+
+    """
+    pytest-qt does not invoke __del__ automatically.
+    Refer https://github.com/gridhead/gi-loadouts/issues/165
+    for more details.
+    """
+    mock_thread = mocker.MagicMock(spec=QThread)
+    scantest.thread = mock_thread
+    scantest.__del__()
+
+    """
+    Confirm if the thread termination is called
+    """
+    mock_thread.terminate.assert_called_once()
+    scantest.thread = None
+
+
+@pytest.mark.parametrize(
+    "_", [pytest.param(None, id="face.scan: Manually invoke __del__ with RuntimeError")]
+)
+def test_scan_delete_fail(scantest: ScanDialog, mocker: MockerFixture, _: None) -> None:
+    """
+    Test manually invoking __del__ on ScanDialog when thread termination raises RuntimeError
+
+    :return:
+    """
+
+    """
+    pytest-qt does not invoke __del__ automatically.
+    Refer https://github.com/gridhead/gi-loadouts/issues/165
+    for more details.
+    """
+    mock_thread = mocker.MagicMock(spec=QThread)
+    mock_thread.terminate.side_effect = RuntimeError
+    scantest.thread = mock_thread
+    scantest.__del__()
+
+    """
+    Confirm if the thread termination is called
+    """
+    mock_thread.terminate.assert_called_once()
+    scantest.thread = None

--- a/test/face/wind/arti/test_arti_file.py
+++ b/test/face/wind/arti/test_arti_file.py
@@ -157,6 +157,11 @@ def test_arti_save_fail(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture,
     """
 
     """
+    Set the user interface elements to a known state
+    """
+    qtbot.mouseClick(getattr(runner, f"arti_{area}_wipe"), Qt.LeftButton)
+
+    """
     Set the user interface elements as intended
     """
     name = choice([item for item in __artilist__ if item != "None"])
@@ -346,6 +351,11 @@ def test_arti_load_nope(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture,
 
     :return:
     """
+
+    """
+    Set the user interface elements to a known state
+    """
+    qtbot.mouseClick(getattr(runner, f"arti_{area}_wipe"), Qt.LeftButton)
 
     """
     Perform the action of saving the artifact information

--- a/test/face/wind/team/test_team_file.py
+++ b/test/face/wind/team/test_team_file.py
@@ -88,6 +88,11 @@ def test_team_save_fail(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture,
     """
 
     """
+    Set the user interface elements to a known state
+    """
+    qtbot.mouseClick(runner.head_wipe, Qt.LeftButton)
+
+    """
     Set the user interface elements as intended
     """
     for area in ["fwol", "pmod", "sdoe", "gboe", "ccol"]:
@@ -189,6 +194,11 @@ def test_team_load_nope(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture,
 
     :return:
     """
+
+    """
+    Set the user interface elements to a known state
+    """
+    qtbot.mouseClick(runner.head_wipe, Qt.LeftButton)
 
     """
     Perform the action of saving the artifact information

--- a/test/face/wind/test_main.py
+++ b/test/face/wind/test_main.py
@@ -98,10 +98,22 @@ def test_wind_main_fail_continue(runner: MainWindow, mocker: MockerFixture, _: N
     """
 
     """
+    Create a residual temp file matching the cleanup pattern so the loop body executes
+    """
+    residual = NamedTemporaryFile(prefix=conf.data_prefix, suffix=conf.data_suffix, delete=False)
+    residual.close()
+
+    """
     Mock remove function in rsrc.py for excepting FileNotFoundError
     """
     mocker.patch("gi_loadouts.face.rsrc.remove", side_effect=FileNotFoundError)
     make_temp_file()
+
+    """
+    Wipe before moving on
+    """
+    if path.exists(residual.name):
+        remove(residual.name)
 
 
 @pytest.mark.parametrize("_", [pytest.param(None, id="face.wind: Manually invoke __del__")])

--- a/test/face/wind/weap/test_file.py
+++ b/test/face/wind/weap/test_file.py
@@ -15,6 +15,14 @@ from gi_loadouts.face.wind import file
 from gi_loadouts.face.wind.main import MainWindow
 from test import json_type, yaml_type
 
+__charelem__ = {
+    "Venti": "Anemo",
+    "Nahida": "Dendro",
+    "Navia": "Geo",
+    "Raiden Shogun": "Electro",
+    "Furina": "Hydro",
+}
+
 from . import (
     actual_bow,
     actual_catalyst,
@@ -66,6 +74,7 @@ def test_weap_save(
     objc = Family[type][name]()
     levl = choice(objc.levl_bind).value.name
 
+    runner.head_char_elem.setCurrentText(__charelem__[char])
     runner.head_char_name.setCurrentText(char)
     runner.weap_area_name.setCurrentText(name)
     runner.weap_area_levl.setCurrentText(levl)
@@ -125,6 +134,7 @@ def test_weap_save_fail(
     objc = Family[type][name]()
     levl = choice(objc.levl_bind).value.name
 
+    runner.head_char_elem.setCurrentText(__charelem__[char])
     runner.head_char_name.setCurrentText(char)
     runner.weap_area_name.setCurrentText(name)
     runner.weap_area_levl.setCurrentText(levl)
@@ -197,6 +207,7 @@ def test_weap_load_yaml(
     """
     Set the user interface elements as intended
     """
+    runner.head_char_elem.setCurrentText(__charelem__[char])
     runner.head_char_name.setCurrentText(char)
 
     """
@@ -261,6 +272,7 @@ def test_weap_load_json(
     """
     Set the user interface elements as intended
     """
+    runner.head_char_elem.setCurrentText(__charelem__[char])
     runner.head_char_name.setCurrentText(char)
 
     """
@@ -320,6 +332,7 @@ def test_weap_load_nope(
     """
     Set the user interface elements as intended
     """
+    runner.head_char_elem.setCurrentText(__charelem__[char])
     runner.head_char_name.setCurrentText(char)
 
     """
@@ -457,6 +470,7 @@ def test_weap_load_fail_type(
     """
     Set the user interface elements as intended
     """
+    runner.head_char_elem.setCurrentText(__charelem__[char])
     runner.head_char_name.setCurrentText(char)
 
     """
@@ -572,6 +586,7 @@ def test_weap_load_fail_name(
     """
     Set the user interface elements as intended
     """
+    runner.head_char_elem.setCurrentText(__charelem__[char])
     runner.head_char_name.setCurrentText(char)
 
     """
@@ -705,6 +720,7 @@ def test_weap_load_fail_levl(
     """
     Set the user interface elements as intended
     """
+    runner.head_char_elem.setCurrentText(__charelem__[char])
     runner.head_char_name.setCurrentText(char)
 
     """
@@ -821,6 +837,7 @@ def test_weap_load_fail_refn(
     """
     Set the user interface elements as intended
     """
+    runner.head_char_elem.setCurrentText(__charelem__[char])
     runner.head_char_name.setCurrentText(char)
 
     """
@@ -893,6 +910,7 @@ def test_weap_save_yaml_actual(
     objc = Family[type][name]()
     levl = choice(objc.levl_bind).value.name
 
+    runner.head_char_elem.setCurrentText(__charelem__[char])
     runner.head_char_name.setCurrentText(char)
     runner.weap_area_name.setCurrentText(name)
     runner.weap_area_levl.setCurrentText(levl)
@@ -977,6 +995,7 @@ def test_weap_save_json_actual(
     objc = Family[type][name]()
     levl = choice(objc.levl_bind).value.name
 
+    runner.head_char_elem.setCurrentText(__charelem__[char])
     runner.head_char_name.setCurrentText(char)
     runner.weap_area_name.setCurrentText(name)
     runner.weap_area_levl.setCurrentText(levl)
@@ -1037,6 +1056,7 @@ def test_weap_save_nope(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture,
     Set the user interface elements as intended
     """
 
+    runner.head_char_elem.setCurrentText(__charelem__[char])
     runner.head_char_name.setCurrentText(char)
 
     """
@@ -1093,6 +1113,7 @@ def test_weap_load_yaml_actual(
     """
     Set the user interface elements as intended
     """
+    runner.head_char_elem.setCurrentText(__charelem__[char])
     runner.head_char_name.setCurrentText(char)
 
     """
@@ -1159,6 +1180,7 @@ def test_weap_load_json_actual(
     """
     Set the user interface elements as intended
     """
+    runner.head_char_elem.setCurrentText(__charelem__[char])
     runner.head_char_name.setCurrentText(char)
 
     """


### PR DESCRIPTION
Optimize test cases to consume less memory

Fixes #165

## Summary by Sourcery

Optimize and stabilize GUI-related tests to reduce memory usage and cover dialog cleanup behavior.

Bug Fixes:
- Add coverage for ScanDialog destructor behavior to ensure worker threads are terminated or safely handled when cleanup is invoked.

Enhancements:
- Initialize GUI widgets to a known state at the start of artifact and team save/load tests to avoid residual UI state between runs.
- Refactor main window and scan dialog test fixtures to be module-scoped with explicit widget closing to lower resource usage across the test suite.
- Ensure temp files matching the cleanup pattern are created in the main window failure test so the cleanup loop executes meaningfully.

Tests:
- Introduce tests that manually invoke ScanDialog.__del__ to verify thread termination in both success and RuntimeError scenarios.