### PR TITLE
Adapt modal dialog tests from `.show()` to `.exec()`

### DIFF
--- a/test/face/info/test_info.py
+++ b/test/face/info/test_info.py
@@ -1,5 +1,5 @@
 import pytest
-from PySide6.QtCore import Qt, QUrl
+from PySide6.QtCore import Qt, QTimer, QUrl
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import QDialog
 from pytest_mock.plugin import MockerFixture
@@ -20,10 +20,15 @@ def test_info(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture, _: None) 
     """
     Perform the action of clicking the help button
     """
+
+    def handle_dialog() -> None:
+        qtbot.mouseClick(runner.infoobjc.updt, Qt.LeftButton)
+        runner.infoobjc.close()
+
+    mock_open_link = mocker.patch.object(QDesktopServices, "openUrl")
+    QTimer.singleShot(0, handle_dialog)
     qtbot.mouseClick(runner.side_info, Qt.LeftButton)
-    mock_open_url = mocker.patch.object(QDesktopServices, "openUrl")
-    qtbot.mouseClick(runner.infoobjc.updt, Qt.LeftButton)
-    expected_url = QUrl(__releases__)
+    expected_link = QUrl(__releases__)
     """
     Confirm if the user interface elements change accordingly
     """
@@ -35,4 +40,4 @@ def test_info(runner: MainWindow, qtbot: QtBot, mocker: MockerFixture, _: None) 
         runner.infoobjc.comp.text()
         == f"This version is compatible with Genshin Impact {__gicompat_vers__} Phase {__gicompat_part__}"
     )
-    mock_open_url.assert_called_once_with(expected_url)
+    mock_open_link.assert_called_once_with(expected_link)

--- a/test/face/lcns/test_lcns.py
+++ b/test/face/lcns/test_lcns.py
@@ -1,5 +1,5 @@
 import pytest
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QTimer
 from PySide6.QtWidgets import QDialog
 from pytestqt.qtbot import QtBot
 
@@ -18,6 +18,8 @@ def test_lcns(runner: MainWindow, qtbot: QtBot, _: None) -> None:
     """
     Perform the action of clicking the info button
     """
+
+    QTimer.singleShot(0, lambda: runner.lcnsobjc.close())
     qtbot.mouseClick(runner.side_lcns, Qt.LeftButton)
     """
     Confirm if the user interface elements change accordingly

--- a/test/face/otpt/test_otpt.py
+++ b/test/face/otpt/test_otpt.py
@@ -1,8 +1,8 @@
 from random import choice
 
 import pytest
-from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QMainWindow, QMessageBox
+from PySide6.QtCore import Qt, QTimer
+from PySide6.QtWidgets import QDialog, QMessageBox
 from pytestqt.qtbot import QtBot
 
 from gi_loadouts import __versdata__
@@ -208,18 +208,19 @@ def test_otpt(runner: MainWindow, qtbot: QtBot, type: str, cond: str) -> None:
     """
     Perform the action of clicking the help button
     """
+
+    QTimer.singleShot(0, lambda: runner.otptobjc.close())
     qtbot.mouseClick(runner.head_scan, Qt.LeftButton)
 
     """
     Confirm if the user interface elements change accordingly
     """
     assert runner.head_scan.toolTip() == "Generate"
-    assert isinstance(runner.otptobjc, QMainWindow)
+    assert isinstance(runner.otptobjc, QDialog)
     assert (
         runner.otptobjc.windowTitle()
         == f"Loadouts for Genshin Impact v{__versdata__} - {runner.head_char_name.currentText()}"
     )
-    assert runner.otptobjc.windowModality() == Qt.ApplicationModal
     assert runner.otptobjc.head_area_line_prim.text() == f"<b>{c_name}</b> - {c_levl} ({c_cons})"
     assert (
         runner.otptobjc.head_area_line_seco.text()

--- a/test/face/scan/__init__.py
+++ b/test/face/scan/__init__.py
@@ -196,7 +196,7 @@ __rtrn_flty__ = {
 
 
 class MockScanDialog:
-    def __init__(self, part: str):
+    def __init__(self, part: str, parent=None):
         self.part = part
         self.pair = {
             "fwol": "Flower of Life",

--- a/test/face/scan/test_scan.py
+++ b/test/face/scan/test_scan.py
@@ -923,7 +923,7 @@ def test_scan_arti_load_fail(
     [
         pytest.param(
             item,
-            lambda part, item=item: MockScanDialog(__dist__[item]["part"]),
+            lambda part, item=item, **kwargs: MockScanDialog(__dist__[item]["part"]),
             id=f"face.scan.rule: Importing {item} artifact information in MainWindow",
         )
         for item in __dist__.keys()


### PR DESCRIPTION
Adapt modal dialog tests from `.show()` to `.exec()`

Fixes #635

## Summary by Sourcery

Adapt modal dialog tests to reliably exercise and dismiss dialogs opened through executable modal interactions.

Bug Fixes:
- Update modal dialog tests to close dialogs asynchronously so they work with the executable dialog behavior.

Enhancements:
- Align dialog type assertions and test doubles with the current modal dialog interfaces.

Tests:
- Adapt information, license, and loadout dialog tests from non-blocking display handling to executable modal dialogs.