### PR TITLE
Avoid header style overriding by parent widget stylesheets

### DIFF
--- a/assets/info.ui
+++ b/assets/info.ui
@@ -110,6 +110,9 @@
      <pointsize>20</pointsize>
     </font>
    </property>
+   <property name="styleSheet">
+    <string notr="true">font: 20pt &quot;Inter&quot;;</string>
+   </property>
    <property name="text">
     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Loadouts for Genshin Impact&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
    </property>

--- a/assets/lcns.ui
+++ b/assets/lcns.ui
@@ -110,6 +110,9 @@
      <pointsize>20</pointsize>
     </font>
    </property>
+   <property name="styleSheet">
+    <string notr="true">font: 20pt &quot;Inter&quot;;</string>
+   </property>
    <property name="text">
     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Loadouts for Genshin Impact&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
    </property>

--- a/gi_loadouts/face/info/info.py
+++ b/gi_loadouts/face/info/info.py
@@ -6,17 +6,8 @@
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
 
-from PySide6.QtCore import (
-    QCoreApplication,
-    QMetaObject,
-    QRect,
-    QSize,
-    Qt,
-)
-from PySide6.QtGui import (
-    QFont,
-    QPixmap,
-)
+from PySide6.QtCore import QCoreApplication, QMetaObject, QRect, QSize, Qt
+from PySide6.QtGui import QFont, QPixmap
 from PySide6.QtWidgets import QLabel, QPushButton, QSizePolicy
 
 
@@ -57,6 +48,7 @@ class Ui_info:
         font1.setFamilies(["Inter"])
         font1.setPointSize(20)
         self.head.setFont(font1)
+        self.head.setStyleSheet('font: 20pt "Inter";')
         self.head.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.vers = QLabel(info)
         self.vers.setObjectName("vers")

--- a/gi_loadouts/face/lcns/lcns.py
+++ b/gi_loadouts/face/lcns/lcns.py
@@ -48,6 +48,7 @@ class Ui_lcns:
         font1.setFamilies(["Inter"])
         font1.setPointSize(20)
         self.head.setFont(font1)
+        self.head.setStyleSheet('font: 20pt "Inter";')
         self.head.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.vers = QLabel(lcns)
         self.vers.setObjectName("vers")


### PR DESCRIPTION
Avoid header style overriding by parent widget stylesheets

Fixes #637

## Summary by Sourcery

Bug Fixes:
- Prevent parent widget stylesheets from overriding the font styling of information and licenses page headers.