### PR TITLE
Center dialogs over parent widget on all platforms

### DIFF
--- a/gi_loadouts/face/info/main.py
+++ b/gi_loadouts/face/info/main.py
@@ -1,7 +1,7 @@
 from time import time
 
 from PySide6.QtCore import QUrl
-from PySide6.QtGui import QDesktopServices, QPixmap
+from PySide6.QtGui import QDesktopServices, QMoveEvent, QPixmap, QShowEvent
 from PySide6.QtWidgets import QDialog
 
 from ... import __gicompat_part__, __gicompat_vers__, __releases__, __versdata__
@@ -19,6 +19,36 @@ class InfoDialog(QDialog, Ui_info):
             f"This version is compatible with Genshin Impact {__gicompat_vers__} Phase {__gicompat_part__}"
         )
         self.updt.clicked.connect(self.open_update_link)
+
+    def showEvent(self, event: QShowEvent) -> None:
+        """
+        Center the dialog box over the parent window
+        GNOME/Wayland does not need but Windows does
+
+        :param event:
+        :return:
+        """
+        if self.parent():
+            self.tocenter = True
+            geo = self.parent().geometry()
+            self.move(
+                geo.center().x() - self.width() // 2,
+                geo.center().y() - self.height() // 2,
+            )
+            self.tocenter = False
+        super().showEvent(event)
+
+    def moveEvent(self, event: QMoveEvent) -> None:
+        """
+        Move the parent window along with the dialog
+        GNOME/Wayland does not need but Windows does
+
+        :param event:
+        :return:
+        """
+        if self.parent() and not getattr(self, "tocenter", False):
+            self.parent().move(self.parent().pos() + event.pos() - event.oldPos())
+        super().moveEvent(event)
 
     def open_update_link(self):
         QDesktopServices.openUrl(QUrl(__releases__))

--- a/gi_loadouts/face/lcns/main.py
+++ b/gi_loadouts/face/lcns/main.py
@@ -1,6 +1,6 @@
 from time import time
 
-from PySide6.QtGui import QPixmap
+from PySide6.QtGui import QMoveEvent, QPixmap, QShowEvent
 from PySide6.QtWidgets import QDialog
 
 from ... import __gicompat_part__, __gicompat_vers__, __versdata__
@@ -17,3 +17,33 @@ class LcnsDialog(QDialog, Ui_lcns):
         self.comp.setText(
             f"This version is compatible with Genshin Impact {__gicompat_vers__} Phase {__gicompat_part__}"
         )
+
+    def showEvent(self, event: QShowEvent) -> None:
+        """
+        Center the dialog box over the parent window
+        GNOME/Wayland does not need but Windows does
+
+        :param event:
+        :return:
+        """
+        if self.parent():
+            self.tocenter = True
+            geo = self.parent().geometry()
+            self.move(
+                geo.center().x() - self.width() // 2,
+                geo.center().y() - self.height() // 2,
+            )
+            self.tocenter = False
+        super().showEvent(event)
+
+    def moveEvent(self, event: QMoveEvent) -> None:
+        """
+        Move the parent window along with the dialog
+        GNOME/Wayland does not need but Windows does
+
+        :param event:
+        :return:
+        """
+        if self.parent() and not getattr(self, "tocenter", False):
+            self.parent().move(self.parent().pos() + event.pos() - event.oldPos())
+        super().moveEvent(event)

--- a/gi_loadouts/face/otpt/rule.py
+++ b/gi_loadouts/face/otpt/rule.py
@@ -1,4 +1,4 @@
-from PySide6.QtGui import QPixmap
+from PySide6.QtGui import QMoveEvent, QPixmap, QShowEvent
 from PySide6.QtWidgets import QDialog
 
 from ...face.util import modify_graphics_resource
@@ -12,6 +12,36 @@ class Rule(QDialog, Ui_otptwind):
         self.char = None
         self.weap = None
         self.tyvt = None
+
+    def showEvent(self, event: QShowEvent) -> None:
+        """
+        Center the dialog box over the parent window
+        GNOME/Wayland does not need but Windows does
+
+        :param event:
+        :return:
+        """
+        if self.parent():
+            self.tocenter = True
+            geo = self.parent().geometry()
+            self.move(
+                geo.center().x() - self.width() // 2,
+                geo.center().y() - self.height() // 2,
+            )
+            self.tocenter = False
+        super().showEvent(event)
+
+    def moveEvent(self, event: QMoveEvent) -> None:
+        """
+        Move the parent window along with the dialog
+        GNOME/Wayland does not need but Windows does
+
+        :param event:
+        :return:
+        """
+        if self.parent() and not getattr(self, "tocenter", False):
+            self.parent().move(self.parent().pos() + event.pos() - event.oldPos())
+        super().moveEvent(event)
 
     def populate_blanks(self) -> None:
         """

--- a/gi_loadouts/face/scan/main.py
+++ b/gi_loadouts/face/scan/main.py
@@ -6,8 +6,7 @@ from .rule import Rule
 
 class ScanDialog(Rule):
     def __init__(self, part: str = "", parent=None) -> None:
-        super().__init__()
-        self.setParent(parent, self.windowFlags())
+        super().__init__(parent=parent)
         self.part = part
         self.setupUi(self)
         self.setWindowTitle(f"Loadouts for Genshin Impact v{__versdata__}")

--- a/gi_loadouts/face/scan/rule.py
+++ b/gi_loadouts/face/scan/rule.py
@@ -3,7 +3,7 @@ import io
 from PIL import Image
 from PIL.ImageQt import QBuffer
 from PySide6.QtCore import QByteArray, QMimeData, QThread
-from PySide6.QtGui import QDragEnterEvent, QDropEvent, QPixmap
+from PySide6.QtGui import QDragEnterEvent, QDropEvent, QMoveEvent, QPixmap, QShowEvent
 from PySide6.QtWidgets import QApplication, QComboBox, QDialog, QLineEdit, QMessageBox
 
 from ... import conf
@@ -29,8 +29,8 @@ from .work import ScanWorker
 
 
 class Rule(QDialog, Ui_scan, Dialog):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
         self.shot = None
         self.snap = None
         self.part = ""
@@ -44,6 +44,36 @@ class Rule(QDialog, Ui_scan, Dialog):
             "Goblet of Eonothem": {"list": MainStatType_GBOE, "part": "gboe"},
             "Circlet of Logos": {"list": MainStatType_CCOL, "part": "ccol"},
         }
+
+    def showEvent(self, event: QShowEvent) -> None:
+        """
+        Center the dialog box over the parent window
+        GNOME/Wayland does not need but Windows does
+
+        :param event:
+        :return:
+        """
+        if self.parent():
+            self.tocenter = True
+            geo = self.parent().geometry()
+            self.move(
+                geo.center().x() - self.width() // 2,
+                geo.center().y() - self.height() // 2,
+            )
+            self.tocenter = False
+        super().showEvent(event)
+
+    def moveEvent(self, event: QMoveEvent) -> None:
+        """
+        Move the parent window along with the dialog
+        GNOME/Wayland does not need but Windows does
+
+        :param event:
+        :return:
+        """
+        if self.parent() and not getattr(self, "tocenter", False):
+            self.parent().move(self.parent().pos() + event.pos() - event.oldPos())
+        super().moveEvent(event)
 
     def __del__(self):
         """


### PR DESCRIPTION
Center dialogs over parent widget on all platforms

Fixes #631

## Summary by Sourcery

Ensure application dialogs open centered over their parent windows consistently across platforms.

New Features:
- Center informational, license, rule, and scan dialogs over their parent windows across supported platforms.
- Keep parent windows aligned when dialogs are repositioned on platforms that do not automatically preserve dialog placement.

Enhancements:
- Preserve dialog-parent relationships during scan dialog construction so platform-independent positioning works consistently.