### PR TITLE
Resolve `ScanDialog` parent passing usage inconsistency

### DIFF
--- a/gi_loadouts/face/scan/main.py
+++ b/gi_loadouts/face/scan/main.py
@@ -6,8 +6,7 @@ from .rule import Rule
 
 class ScanDialog(Rule):
     def __init__(self, part: str = "", parent=None) -> None:
-        super().__init__()
-        self.setParent(parent, self.windowFlags())
+        super().__init__(parent=parent)
         self.part = part
         self.setupUi(self)
         self.setWindowTitle(f"Loadouts for Genshin Impact v{__versdata__}")

--- a/gi_loadouts/face/scan/rule.py
+++ b/gi_loadouts/face/scan/rule.py
@@ -29,8 +29,8 @@ from .work import ScanWorker
 
 
 class Rule(QDialog, Ui_scan, Dialog):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
         self.shot = None
         self.snap = None
         self.part = ""


### PR DESCRIPTION
Resolve `ScanDialog` parent passing usage inconsistency

Fixes #631

## Summary by Sourcery

Standardize parent handling across the scan dialog initialization hierarchy.

Bug Fixes:
- Ensure `ScanDialog` consistently passes its parent to the dialog hierarchy during initialization.

Enhancements:
- Allow `Rule` dialog initialization to accept and forward constructor keyword arguments.